### PR TITLE
feat: Manual Test Strategy agents + skill (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this repository should be recorded in this file.
 
+## 0.5.0 - 2026-03-19
+
+- Added `agents/manual-test-strategy.agent.md`: produces decision rubric, exploratory charter, regression checklist, defect template, and automation backlog; files GitHub Issues for all automation candidates
+- Added `agents/exploratory-charter.agent.md`: generates time-boxed exploratory sessions with mission, scope, evidence capture, and triage routing; files GitHub Issues for automation-worthy findings
+- Added `agents/strategy-to-automation.agent.md`: converts manual paths into tiered automation candidates (smoke, regression, integration, agent spec); files a GitHub Issue for every candidate without exception
+- Added `skills/manual-test-strategy/SKILL.md`: skill description, when to use, and agent invocation guide
+- Added `skills/manual-test-strategy/rubric-template.md`: decision rubric template for manual-only, automate-now, and hybrid classification with risk scoring matrix
+- Added `skills/manual-test-strategy/charter-template.md`: exploratory charter template with mission, time box, scope, evidence log, and triage routing
+- Added `skills/manual-test-strategy/checklist-template.md`: regression checklist template with automation candidate flagging
+- Added `skills/manual-test-strategy/defect-template.md`: defect evidence template with reproduction steps, impact, diagnostic context, and automation handoff section
+- Updated `instructions/testing.instructions.md`: added Manual Test Strategy section referencing all three agents, the skill, the decision rubric, and automation handoff expectations
+
 ## 0.4.2 - 2026-03-19
 
 - Fixed Windows PowerShell test runner to clear expected nonzero scanner exit codes

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -22,6 +22,7 @@ This catalog helps teams discover what exists in Base Coat and when to use it.
 
 | File                                    | Use For                                                 | Keywords                                     |
 | --------------------------------------- | ------------------------------------------------------- | -------------------------------------------- |
+| `skills/manual-test-strategy/SKILL.md`  | define manual scope, produce charters, checklists, and handoff artifacts | manual testing, exploratory, charter, regression, defect, automation handoff |
 | `skills/performance-profiling/SKILL.md` | isolate and measure slow code paths                     | profiling, performance, latency, hot path    |
 | `skills/code-review/SKILL.md`           | review changes for risk, regressions, and missing tests | review, bug risk, regression, findings       |
 | `skills/refactoring/SKILL.md`           | restructure code without changing behavior              | refactor, cleanup, simplify, extract, rename |
@@ -40,6 +41,9 @@ This catalog helps teams discover what exists in Base Coat and when to use it.
 
 | File                                | Use For                                        | Keywords                                  |
 | ----------------------------------- | ---------------------------------------------- | ----------------------------------------- |
+| `agents/manual-test-strategy.agent.md`  | produce a full manual test strategy with rubric, charter, checklist, defect template, and automation backlog | agent, manual testing, strategy, exploratory, automation candidate |
+| `agents/exploratory-charter.agent.md`   | generate time-boxed exploratory sessions with scope, evidence capture, and GitHub Issue filing              | agent, exploratory, charter, session, findings |
+| `agents/strategy-to-automation.agent.md`| convert manual paths into tiered automation candidates and file GitHub Issues for every one                | agent, automation, smoke, regression, integration, candidate |
 | `agents/code-review.agent.md`       | multi-step repository review process           | agent, review, repo scan, risk            |
 | `agents/new-customization.agent.md` | choose and create the right customization type | agent, customization, instruction, prompt |
 | `agents/rollout-basecoat.agent.md`  | onboard a repo to a pinned Base Coat release   | agent, rollout, bootstrap, enterprise     |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ basecoat/
 - [instructions/bicep.instructions.md](/c:/git/basecoat/instructions/bicep.instructions.md): Bicep authoring guidance and validation practices
 - [instructions/naming.instructions.md](/c:/git/basecoat/instructions/naming.instructions.md): naming conventions across repos, code, and infrastructure
 - [instructions/mcp.instructions.md](/c:/git/basecoat/instructions/mcp.instructions.md): MCP server and tool governance, safety, and enforcement guidance
+- [skills/manual-test-strategy/SKILL.md](/c:/git/basecoat/skills/manual-test-strategy/SKILL.md): workflow for defining manual scope, producing charters, checklists, and automation handoff artifacts
 - [skills/performance-profiling/SKILL.md](/c:/git/basecoat/skills/performance-profiling/SKILL.md): workflow for profiling slow paths
 - [skills/code-review/SKILL.md](/c:/git/basecoat/skills/code-review/SKILL.md): review-first workflow focused on risk detection
 - [skills/refactoring/SKILL.md](/c:/git/basecoat/skills/refactoring/SKILL.md): workflow for safe structural cleanup
@@ -52,6 +53,9 @@ basecoat/
 - [prompts/architect.prompt.md](/c:/git/basecoat/prompts/architect.prompt.md): architecture planning starter
 - [prompts/code-review.prompt.md](/c:/git/basecoat/prompts/code-review.prompt.md): code review starter
 - [prompts/bugfix.prompt.md](/c:/git/basecoat/prompts/bugfix.prompt.md): root-cause bugfix starter
+- [agents/manual-test-strategy.agent.md](/c:/git/basecoat/agents/manual-test-strategy.agent.md): produce a complete manual test strategy with rubric, charter, checklist, defect template, and automation backlog
+- [agents/exploratory-charter.agent.md](/c:/git/basecoat/agents/exploratory-charter.agent.md): generate time-boxed exploratory sessions with evidence capture and GitHub Issue filing
+- [agents/strategy-to-automation.agent.md](/c:/git/basecoat/agents/strategy-to-automation.agent.md): convert manual paths into tiered automation candidates with a GitHub Issue filed for every one
 - [agents/code-review.agent.md](/c:/git/basecoat/agents/code-review.agent.md): multi-step review agent definition draft
 - [agents/new-customization.agent.md](/c:/git/basecoat/agents/new-customization.agent.md): workflow for creating the right customization primitive
 - [agents/rollout-basecoat.agent.md](/c:/git/basecoat/agents/rollout-basecoat.agent.md): workflow for onboarding a repo to a pinned Base Coat release

--- a/agents/exploratory-charter.agent.md
+++ b/agents/exploratory-charter.agent.md
@@ -1,0 +1,70 @@
+---
+description: "Use when you need time-boxed exploratory testing sessions. Generates mission-driven charters with scope, triage routing, and evidence capture. Automatically files GitHub Issues for automation candidates found during exploration."
+---
+
+# Exploratory Charter Agent
+
+Purpose: generate one or more time-boxed exploratory testing sessions with a clear mission, scope, evidence format, and triage routing so findings are reproducible and actionable by any team member.
+
+## Inputs
+
+- Feature area or risk theme to explore
+- Available time budget per session (default: 60 minutes if not stated)
+- Known open questions, edge cases, or environmental differences
+- Any existing charter or checklist context
+
+## Process
+
+1. Define a focused mission statement for each session: what question is the session trying to answer?
+2. Set the time box: a hard boundary on session duration.
+3. Define scope: what is in bounds and what is explicitly out of bounds.
+4. Define the evidence capture format using `skills/manual-test-strategy/defect-template.md` for bugs, and structured observation notes for other findings.
+5. Set triage routing: who receives bug reports, which label or queue gets automation candidates, and how observations feed back into the strategy.
+6. Identify findings that are strong automation candidates (high frequency, deterministic, repeatable).
+7. File a GitHub Issue for every finding worth automating.
+
+## GitHub Issue Filing
+
+For every exploration finding worth automating, run:
+
+```bash
+gh issue create \
+  --title "[Automation Candidate] <short description>" \
+  --label "testing,automation-candidate" \
+  --body "## Automation Candidate
+
+**Priority:** <high | medium | low>
+**Risk Level:** <high | medium | low>
+**Test Type:** <smoke | regression | integration | exploratory>
+
+### Description
+<what was discovered during the charter session and why it should be automated>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+### Charter Reference
+**Mission:** <charter mission statement>
+**Session date / time box:** <date and duration>
+**Finding:** <what was observed>
+
+### Notes
+<reproduction steps summary, environment, or any prerequisite state>"
+```
+
+If a sprint label is applicable, append `--label "<sprint-label>"`.
+
+## Expected Output
+
+For each session, produce a charter following `skills/manual-test-strategy/charter-template.md` that includes:
+
+- **Mission**: the specific question the session is answering
+- **Time box**: hard session limit
+- **Scope**: in-bounds areas and explicit out-of-bounds
+- **Setup**: prerequisite state, accounts, or environment notes
+- **Evidence capture**: what to record (screenshots, logs, repro steps, error messages)
+- **Triage routing**: how findings are classified and routed (bug, automation candidate, observation)
+- **Exit criteria**: what ends the session successfully
+
+After the session, produce a brief findings summary with filed GitHub Issues for automation candidates.

--- a/agents/manual-test-strategy.agent.md
+++ b/agents/manual-test-strategy.agent.md
@@ -1,0 +1,61 @@
+---
+description: "Use when you need a structured manual testing strategy for a feature or risk inventory. Produces a decision rubric, exploratory charter, regression checklist, defect template, and automation backlog. Automatically files GitHub Issues for automation candidates."
+---
+
+# Manual Test Strategy Agent
+
+Purpose: turn a feature description or risk inventory into a complete, actionable manual testing strategy with explicit decision rules and evidence-ready artifacts.
+
+## Inputs
+
+- Feature description or user story
+- Known risk areas or change impact summary
+- Existing scripted coverage status (what is already automated, if anything)
+
+## Process
+
+1. Inventory core behaviors and classify each as manual-only, automate-now, or hybrid using the decision rubric from `skills/manual-test-strategy/rubric-template.md`.
+2. Document positive and negative manual test paths with expected evidence and clear pass-fail or bug-report outcomes.
+3. Produce an exploratory charter for areas where human judgment is required (use `skills/manual-test-strategy/charter-template.md`).
+4. Produce a regression checklist for repeated, stable checks (use `skills/manual-test-strategy/checklist-template.md`).
+5. Produce a defect evidence template capturing reproduction steps, impact, and diagnostic context (use `skills/manual-test-strategy/defect-template.md`).
+6. Identify automation backlog candidates: repeated checks with high business value, stable inputs, and deterministic outputs.
+7. For each automation candidate, file a GitHub Issue using the pattern below.
+
+## GitHub Issue Filing
+
+For every identified automation backlog candidate, run:
+
+```bash
+gh issue create \
+  --title "[Automation Candidate] <short description>" \
+  --label "testing,automation-candidate" \
+  --body "## Automation Candidate
+
+**Priority:** <high | medium | low>
+**Risk Level:** <high | medium | low>
+**Test Type:** <smoke | regression | integration | exploratory>
+
+### Description
+<what the manual path does and why it is a candidate for automation>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+### Manual Path Reference
+<which charter, checklist item, or rubric row this came from>
+
+### Notes
+<any constraints, dependencies, or environment-specific concerns>"
+```
+
+If a sprint label is applicable, append `--label "<sprint-label>"`.
+
+## Expected Output
+
+- Decision rubric with every classified behavior justified
+- At least one exploratory charter or regression checklist (both when scope warrants it)
+- Defect evidence template ready for immediate use
+- Automation backlog list with priorities and filed GitHub Issues
+- PR summary including assumptions, coverage boundaries, and next actions

--- a/agents/strategy-to-automation.agent.md
+++ b/agents/strategy-to-automation.agent.md
@@ -1,0 +1,90 @@
+---
+description: "Use when converting manual test paths into automation candidates. Maps paths to smoke tests, regression tiers, or agent specs. ALWAYS files a GitHub Issue for every automation candidate identified."
+---
+
+# Strategy to Automation Agent
+
+Purpose: convert manual test paths, charter findings, and regression checklist items into prioritized automation candidates, and file a GitHub Issue for every candidate without exception.
+
+## Inputs
+
+- Manual test strategy output, exploratory charter findings, or regression checklist
+- Decision rubric rows classified as automate-now or hybrid
+- Risk inventory with frequency, business impact, and observability notes
+
+## Process
+
+1. Review each manual path and rubric classification.
+2. Classify each automation candidate into the appropriate test tier:
+   - **Smoke**: proves the system is alive; smallest set of critical-path checks
+   - **Regression**: repeated, stable checks that protect behavior after change
+   - **Integration**: validates behavior across boundaries (service-to-service, UI-to-API)
+   - **Agent spec**: multi-step scenarios requiring orchestration or state management
+3. For each candidate, produce a concise automation spec that includes:
+   - What behavior is under test (in plain language, no tooling specifics)
+   - Positive path: inputs, expected result, observable evidence
+   - Negative path: invalid inputs or failure conditions, expected outcome
+   - Priority and risk level
+   - Acceptance criteria
+4. File a GitHub Issue for **every** candidate. This step is not optional.
+
+## GitHub Issue Filing
+
+For every automation candidate, run:
+
+```bash
+gh issue create \
+  --title "[Automation Candidate] <short description>" \
+  --label "testing,automation-candidate" \
+  --body "## Automation Candidate
+
+**Priority:** <high | medium | low>
+**Risk Level:** <high | medium | low>
+**Test Type:** <smoke | regression | integration | agent-spec>
+
+### Behavior Under Test
+<plain-language description of what this test validates>
+
+### Positive Path
+- **Input:** <input or precondition>
+- **Expected result:** <observable outcome>
+- **Evidence:** <what to check: response, state, log, UI element>
+
+### Negative Path
+- **Input:** <invalid input or failure condition>
+- **Expected result:** <safe failure outcome>
+- **Evidence:** <what to check>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+### Source
+**Manual path / charter / checklist item:** <reference>
+**Rubric classification:** <automate-now | hybrid>
+
+### Notes
+<dependencies, environment constraints, or prerequisite state>"
+```
+
+If a sprint label is applicable, append `--label "<sprint-label>"`.
+
+## Output Shape
+
+For each manual path converted:
+
+1. Tier classification (smoke, regression, integration, or agent spec) with justification
+2. Automation spec in plain language (no tooling lock-in)
+3. Confirmed GitHub Issue filed with `automation-candidate` label
+
+Produce a summary table at the end:
+
+| Path | Tier | Priority | Risk | Issue Filed |
+|------|------|----------|------|-------------|
+| ... | ... | ... | ... | #N |
+
+## Non-Goals
+
+- Do not write implementation code for any specific test framework.
+- Do not assume a particular runner, language, or CI toolchain.
+- Do not defer issue filing — every candidate gets an issue before the session ends.

--- a/instructions/testing.instructions.md
+++ b/instructions/testing.instructions.md
@@ -37,3 +37,42 @@ Use this instruction when adding or modifying tests, or when validating risky ch
 - Manual verification steps are noted when automation is missing.
 - The test names make the protected behavior obvious.
 - Positive and negative scenarios are both represented for changed behavior.
+
+## Manual Test Strategy
+
+Use the manual test strategy agents and skill when a change or feature needs explicit decisions about where human judgment is still required and what should graduate into automation.
+
+### When to Apply
+
+- A new feature or risk area has no documented manual scope.
+- Exploratory work is informal or undocumented.
+- A checklist or charter needs to be reproducible by a new team member.
+- Automation candidates from manual testing need to be captured and filed.
+
+### Agents
+
+- **`agents/manual-test-strategy.agent.md`**: produces the full strategy — decision rubric, exploratory charter, regression checklist, defect template, and automation backlog with GitHub Issues filed for every candidate.
+- **`agents/exploratory-charter.agent.md`**: generates one or more time-boxed exploratory sessions with mission, scope, evidence format, and triage routing. Files GitHub Issues for automation-worthy findings.
+- **`agents/strategy-to-automation.agent.md`**: converts manual paths and rubric rows into tiered automation candidates (smoke, regression, integration, or agent spec) and files a GitHub Issue for every candidate without exception.
+
+### Skill
+
+- **`skills/manual-test-strategy/`**: provides the rubric, charter, checklist, and defect templates used by all three agents.
+
+### Decision Rubric
+
+Every behavior under manual test scope should be classified as one of:
+
+| Classification | When to use |
+| --- | --- |
+| **Manual-only** | Human judgment required; exploratory, context-dependent, or infrequent |
+| **Automate-now** | Stable, deterministic, high-value, frequently repeated |
+| **Hybrid** | Core path can be scripted; edge cases or environment variation still need a manual pass |
+
+See `skills/manual-test-strategy/rubric-template.md` for the full scoring matrix.
+
+### Automation Handoff
+
+- Automation candidates are never left implicit. Every identified candidate is filed as a GitHub Issue with labels `testing` and `automation-candidate`.
+- Defect evidence records include an automation handoff section so future scripted coverage is easier to prioritize.
+- Keep all strategy artifacts stack-agnostic: no framework-specific references belong in rubrics, charters, or checklists.

--- a/skills/manual-test-strategy/SKILL.md
+++ b/skills/manual-test-strategy/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: manual-test-strategy
+description: "Use when defining where human judgment is still required, how exploratory work is captured, and which repeated checks should graduate into automation. Provides templates for decision rubrics, exploratory charters, regression checklists, and defect evidence."
+---
+
+# Manual Test Strategy
+
+Use this skill when a feature, risk inventory, or change needs a structured decision about what stays manual, what gets automated next, and how evidence moves between both.
+
+## When to Use
+
+- A new feature or risk area lacks explicit manual testing scope.
+- Exploratory coverage is informal or undocumented.
+- A manual regression checklist needs to be made repeatable by a new team member.
+- Automation candidates need to be captured and prioritized from manual work.
+- A defect requires a structured evidence record for filing or future automation.
+
+## How Agents Invoke This Skill
+
+Agents should load the relevant template from this skill's directory before producing artifacts:
+
+| Template | When to use |
+| --- | --- |
+| `rubric-template.md` | Classifying behaviors as manual-only, automate-now, or hybrid |
+| `charter-template.md` | Structuring a time-boxed exploratory session |
+| `checklist-template.md` | Building a repeatable manual regression checklist |
+| `defect-template.md` | Capturing defect evidence for filing, triage, or automation handoff |
+
+## Workflow
+
+1. Inventory behaviors: list all behaviors that could be tested, noting change frequency, business risk, and existing scripted coverage.
+2. Apply the rubric: classify each behavior using `rubric-template.md`.
+3. Produce artifacts: charter, checklist, or both depending on what the rubric produces.
+4. Capture evidence: use `defect-template.md` for any found defects.
+5. Identify automation candidates: any hybrid or automate-now row that is not yet scripted becomes a backlog candidate.
+6. File GitHub Issues for automation candidates using the `gh issue create` pattern defined in the relevant agent.
+
+## Output Expectations
+
+- Every behavior is classified; no implicit scope.
+- Evidence is rich enough for a new team member to reproduce findings without tribal knowledge.
+- Automation handoff is explicit: candidates are named, prioritized, and tracked as GitHub Issues.
+- Artifacts remain stack-agnostic: no tooling-specific references in templates.

--- a/skills/manual-test-strategy/charter-template.md
+++ b/skills/manual-test-strategy/charter-template.md
@@ -1,0 +1,111 @@
+# Exploratory Charter Template
+
+Use this template for each time-boxed exploratory testing session. Fill in every field before starting the session. Evidence captured during the session is appended to the **Findings** section.
+
+---
+
+## Charter
+
+**Mission**
+_State the specific question this session is trying to answer. One sentence preferred._
+
+> Example: "Explore how the system behaves when a user submits a form with valid input but an expired authentication token."
+
+**Time Box**
+_Hard limit on session duration. Stop when this expires regardless of findings._
+
+> `__ minutes` (default: 60 minutes)
+
+**Tester**
+_Who is running this session._
+
+**Date**
+
+**Feature / Area**
+_What product area or risk theme is in scope._
+
+---
+
+## Scope
+
+**In Bounds**
+_List what will be actively tested during this session._
+
+- 
+- 
+
+**Out of Bounds**
+_List what is explicitly excluded so the session stays focused._
+
+- 
+- 
+
+---
+
+## Setup
+
+**Prerequisite state**
+_What must be true before starting: accounts, data, environment, feature flags._
+
+- 
+- 
+
+**Environment**
+_Where the session runs: local, staging, production-like, other._
+
+---
+
+## Evidence Capture
+
+Record findings in real time using the following structure. For bugs, use `defect-template.md`. For other observations, use the format below.
+
+### Observation Log
+
+| # | Time | Area | Observation | Type | Severity |
+| --- | --- | --- | --- | --- | --- |
+| 1 | | | | Bug / Risk / Question / Insight | Critical / High / Medium / Low |
+| 2 | | | | | |
+
+**Types:**
+- **Bug** — confirmed defect; fill in `defect-template.md`
+- **Risk** — potential issue requiring follow-up investigation
+- **Question** — unclear behavior that needs specification clarification
+- **Insight** — useful observation that may inform automation or future testing
+
+---
+
+## Triage Routing
+
+| Finding type | Route to |
+| --- | --- |
+| Bug (critical / high) | File immediately with defect evidence; notify team |
+| Bug (medium / low) | File in bug backlog with defect evidence |
+| Automation candidate | Hand off to `strategy-to-automation` agent; file GitHub Issue with `automation-candidate` label |
+| Risk | Add to risk register or open a tracking issue |
+| Question | Raise in spec review or with product owner |
+
+---
+
+## Exit Criteria
+
+The session ends when:
+- [ ] The time box expires, OR
+- [ ] The mission question is answered with sufficient evidence, OR
+- [ ] A blocking bug is found that prevents further exploration of in-scope areas
+
+---
+
+## Findings Summary
+
+_Completed after the session._
+
+**Mission answered?** Yes / No / Partially
+
+**Key findings:**
+-
+-
+
+**Automation candidates identified:** _[list or reference filed GitHub Issues]_
+
+**Recommended follow-up:**
+-

--- a/skills/manual-test-strategy/checklist-template.md
+++ b/skills/manual-test-strategy/checklist-template.md
@@ -1,0 +1,87 @@
+# Manual Regression Checklist Template
+
+Use this template to build a repeatable manual regression checklist. Each item must be runnable by a new team member without tribal knowledge. Items that pass the repeatability bar and are run frequently are strong automation candidates.
+
+---
+
+## Context
+
+**Feature / Area:**
+**Version / Build:**
+**Date:**
+**Tester:**
+**Environment:**
+
+---
+
+## How to Use
+
+1. Run each item in order unless the item notes an exception.
+2. Mark each item as **Pass**, **Fail**, or **Skip** with a reason.
+3. For failures, fill in a defect record using `defect-template.md`.
+4. For skipped items, note why and whether they need a follow-up session.
+5. After the run, complete the **Run Summary** section.
+
+---
+
+## Checklist Items
+
+### Group: [Area name — e.g., Core happy path]
+
+| # | Step | Expected result | Pass / Fail / Skip | Notes |
+| --- | --- | --- | --- | --- |
+| 1.1 | | | | |
+| 1.2 | | | | |
+| 1.3 | | | | |
+
+### Group: [Area name — e.g., Negative and error paths]
+
+| # | Step | Expected result | Pass / Fail / Skip | Notes |
+| --- | --- | --- | --- | --- |
+| 2.1 | | | | |
+| 2.2 | | | | |
+| 2.3 | | | | |
+
+### Group: [Area name — e.g., Edge cases and boundary conditions]
+
+| # | Step | Expected result | Pass / Fail / Skip | Notes |
+| --- | --- | --- | --- | --- |
+| 3.1 | | | | |
+| 3.2 | | | | |
+
+---
+
+## Automation Candidate Flags
+
+Mark any item that is a strong automation candidate.
+
+| Item # | Reason it should be automated | Priority |
+| --- | --- | --- |
+| | | |
+
+Items flagged here should be handed off to the `strategy-to-automation` agent with a GitHub Issue filed using the `automation-candidate` label.
+
+---
+
+## Run Summary
+
+| Metric | Count |
+| --- | --- |
+| Total items | |
+| Passed | |
+| Failed | |
+| Skipped | |
+
+**Overall result:** Pass / Fail / Incomplete
+
+**Blocking failures (if any):**
+-
+
+**Defect records filed:**
+-
+
+**Automation candidates flagged:**
+-
+
+**Next actions:**
+-

--- a/skills/manual-test-strategy/defect-template.md
+++ b/skills/manual-test-strategy/defect-template.md
@@ -1,0 +1,96 @@
+# Defect Evidence Template
+
+Use this template whenever a defect is found during manual testing, an exploratory session, or a regression run. Evidence must be rich enough for any team member to reproduce the issue without tribal knowledge. This template also serves as the handoff record for CI triage, bug filing, and future automation.
+
+---
+
+## Defect Record
+
+**Title:** _[Short, specific description of what is wrong]_
+
+**Reported by:**
+**Date:**
+**Environment:** _[local / staging / production-like; OS, browser if relevant]_
+**Build / Version / Commit:**
+**Severity:** Critical / High / Medium / Low
+**Priority:** High / Medium / Low
+
+---
+
+## Reproduction Steps
+
+_List every step required to reproduce the defect from a clean state. Be precise: another tester should be able to follow these steps without asking questions._
+
+1. Start in state: _[describe the required starting state, accounts, data, feature flags]_
+2.
+3.
+4.
+
+**Reproducibility:** Always / Intermittent (___ of ___ attempts) / Not reproduced after filing
+
+---
+
+## Expected Result
+
+_What should have happened based on the specification, design, or reasonable user expectation._
+
+---
+
+## Actual Result
+
+_What actually happened. Include exact error messages, status codes, or visible behavior._
+
+---
+
+## Impact
+
+**Who is affected:** _[all users / authenticated users / admin only / specific segment]_
+**Business impact:** _[describe the consequence: data loss, blocked workflow, degraded UX, etc.]_
+**Workaround available:** Yes / No — _[if yes, describe it]_
+
+---
+
+## Diagnostic Context
+
+_Include any information that helps with root cause analysis or triage. Remove anything that is already obvious from the reproduction steps._
+
+**Logs / error output:**
+```
+[paste relevant log lines or error output here]
+```
+
+**Screenshots or recordings:** _[attach or link]_
+
+**Telemetry references:** _[trace IDs, request IDs, correlation IDs if available]_
+
+**Related tests that should have caught this:** _[list any existing tests or checklist items that cover this area — note if coverage was missing]_
+
+---
+
+## Automation Handoff
+
+_Complete this section if the defect should be prevented by an automated check going forward._
+
+**Should this become an automated test?** Yes / No / Already covered (gap in execution)
+
+**Test type:** smoke / regression / integration / other
+
+**What the automated check should validate:**
+_[plain-language description of the assertion, no tooling specifics]_
+
+**Acceptance criteria for the automated check:**
+- [ ]
+- [ ]
+
+_If yes, hand off to the `strategy-to-automation` agent and file a GitHub Issue with labels `testing` and `automation-candidate`._
+
+---
+
+## Status
+
+| Field | Value |
+| --- | --- |
+| Filed in tracker | Yes / No — [link or ID] |
+| Assigned to | |
+| Fix version | |
+| Verified fixed | Yes / No / Pending |

--- a/skills/manual-test-strategy/rubric-template.md
+++ b/skills/manual-test-strategy/rubric-template.md
@@ -1,0 +1,51 @@
+# Manual vs. Automation Decision Rubric
+
+Use this rubric to classify each behavior or test scenario into one of three categories: **manual-only**, **automate-now**, or **hybrid**. Every row must be filled in with a justification — no implicit scope.
+
+## Classification Definitions
+
+| Classification | Meaning |
+| --- | --- |
+| **Manual-only** | Human judgment is required. The behavior is too exploratory, context-dependent, or infrequently run to justify the cost of automation right now. |
+| **Automate-now** | The behavior is stable, deterministic, repeated frequently enough, and high-value enough that not automating it is a regression risk. |
+| **Hybrid** | The core happy path can be scripted, but edge cases, UI quality, or environmental variation still require a manual pass alongside the automated check. |
+
+## Risk Scoring Factors
+
+Score each factor from 1 (low) to 3 (high) when a more rigorous classification is needed:
+
+| Factor | 1 | 2 | 3 |
+| --- | --- | --- | --- |
+| **Change frequency** | Rarely changes | Changes occasionally | Changes every sprint |
+| **Business impact** | Low visibility, easy recovery | Moderate impact | Critical path, data loss risk |
+| **Observability** | Output is easily checked | Output requires interpretation | Hard to observe without tooling |
+| **Automation value** | High setup cost, low reuse | Moderate reuse | High reuse, deterministic output |
+
+A total score of 8–12 across the four factors is a strong signal for **automate-now**. A score of 4–7 suggests **hybrid**. A score below 4 or where observability is inherently human suggests **manual-only**.
+
+## Rubric Table
+
+Fill in one row per behavior or test scenario.
+
+| # | Behavior / Scenario | Classification | Change Freq | Business Impact | Observability | Automation Value | Score | Justification |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | | | | | | | | |
+| 2 | | | | | | | | |
+| 3 | | | | | | | | |
+
+## Coverage Boundary Summary
+
+After filling the table, complete this summary:
+
+- **Manual-only scope**: _[describe what stays manual and why]_
+- **Automate-now scope**: _[describe what should be scripted immediately]_
+- **Hybrid scope**: _[describe what needs both manual and scripted coverage and how they complement each other]_
+- **Coverage goal**: _[state the expected manual/automated ratio or threshold if one is defined]_
+
+## Automation Backlog
+
+List automation candidates (automate-now or hybrid items not yet scripted) for handoff to the `strategy-to-automation` agent:
+
+| Candidate | Classification | Priority | Notes |
+| --- | --- | --- | --- |
+| | | | |

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "name": "base-coat",
-    "version": "0.4.2",
+    "version": "0.5.0",
     "releaseDate": "2026-03-19",
-    "notes": "Fixed Windows CI exit handling for the commit-message scanner negative test and stabilized release packaging."
+    "notes": "Added manual test strategy agents, skill, and templates. Updated testing instructions with Manual Test Strategy section."
 }


### PR DESCRIPTION
## basecoat v0.5.0 — Manual Test Strategy Integration

### What's new

**3 new agents**
- \manual-test-strategy.agent.md\ — full rubric → charter → checklist → defect template → automation backlog pipeline
- \xploratory-charter.agent.md\ — time-boxed exploration sessions with evidence capture + auto GitHub Issue filing
- \strategy-to-automation.agent.md\ — converts manual paths to tiered automation candidates; files a GitHub Issue for every candidate

**1 new skill** (\skills/manual-test-strategy/\)
- rubric-template.md, charter-template.md, checklist-template.md, defect-template.md, SKILL.md

**Updated**
- \instructions/testing.instructions.md\ — manual strategy section added
- \ersion.json\ → 0.5.0
- CHANGELOG.md, INVENTORY.md, README.md

### Source
Ported and adapted from \eature/level-29-manual-strategy-integration\ branch of Demo-GHCP-TestAutomation.

### Notes
- All agents are framework-agnostic
- Automation candidates auto-file GitHub Issues with \utomation-candidate\ + \	esting\ labels