### PR TITLE
feat: Sprint 1 — Dev Core agents (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this repository should be recorded in this file.
 
+## 0.6.0 - 2026-03-19
+
+- Added `agents/backend-dev.agent.md`: designs and implements REST/GraphQL APIs, service layers, and data access patterns; files GitHub Issues with `tech-debt,backend` labels for N+1 risk, missing validation, unhandled error paths, hardcoded values, and missing auth
+- Added `agents/frontend-dev.agent.md`: builds component-driven UIs with WCAG 2.1 AA accessibility, responsive layouts, and Core Web Vitals targets; files GitHub Issues with `tech-debt,frontend,accessibility` labels for missing ARIA, hardcoded colors, non-semantic markup, missing loading states, and inline styles
+- Added `agents/middleware-dev.agent.md`: designs integration layers, message contracts, API gateways, and event-driven architectures with circuit breaker, retry, DLQ, and idempotency patterns; files GitHub Issues with `tech-debt,middleware,reliability` labels
+- Added `agents/data-tier.agent.md`: designs schemas, writes reversible migrations, optimizes queries, and establishes data access patterns; files GitHub Issues with `tech-debt,data,performance` labels for N+1 queries, missing indexes, SELECT *, missing rollbacks, and hardcoded IDs
+- Added `skills/backend-dev/SKILL.md`: skill overview, invocation guide, and template index
+- Added `skills/backend-dev/api-spec-template.md`: OpenAPI 3.x-compatible API spec skeleton with example paths, components, pagination, and error schemas
+- Added `skills/backend-dev/service-template.md`: service layer scaffold with dependency injection, structured error types, logging stubs, and testing expectations
+- Added `skills/backend-dev/error-catalog-template.md`: structured error catalog with codes, messages, HTTP status codes, and resolution hints
+- Added `skills/backend-dev/repository-pattern-template.md`: data access repository pattern boilerplate with parameterized queries, pagination, and soft delete support
+- Added `skills/frontend-dev/SKILL.md`: skill overview, invocation guide, and template index
+- Added `skills/frontend-dev/component-spec-template.md`: component specification covering props, events, slots, all UI states, accessibility requirements, and test plan
+- Added `skills/frontend-dev/accessibility-checklist.md`: WCAG 2.1 AA checklist organized by perceivable, operable, understandable, and robust principles with issue-filing guidance
+- Added `skills/frontend-dev/state-management-template.md`: state structure template covering local state, shared state, async lifecycle phases, error state, and derived state
+- Added `skills/data-tier/SKILL.md`: skill overview, invocation guide, and template index
+- Added `skills/data-tier/schema-design-template.md`: schema design document covering entities, columns, constraints, indexes, relationships, and ERD scaffold
+- Added `skills/data-tier/migration-template.md`: migration scaffold with up/down blocks, pre-migration checklist, rollback plan, and zero-downtime strategies
+- Added `skills/data-tier/query-review-checklist.md`: query review covering N+1 detection, index usage, pagination, SELECT * checks, and explain plan interpretation
+- Added `skills/data-tier/data-dictionary-template.md`: data dictionary template covering table, column, type, nullable, description, and example values
+- Added `instructions/development.instructions.md`: shared standards for all four dev core agents covering code style, error handling, security, logging, testing, issue filing, and agent collaboration handoff order
+
 ## 0.5.0 - 2026-03-19
 
 - Added `agents/manual-test-strategy.agent.md`: produces decision rubric, exploratory charter, regression checklist, defect template, and automation backlog; files GitHub Issues for all automation candidates

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -12,6 +12,7 @@ This catalog helps teams discover what exists in Base Coat and when to use it.
 | `instructions/security.instructions.md`      | secure coding, auth boundaries, secret handling       | security, auth, secrets, validation, unsafe                        |
 | `instructions/reliability.instructions.md`   | resilience, failure modes, observability              | reliability, retry, timeout, logging, resilience                   |
 | `instructions/documentation.instructions.md` | docs updates and operational notes                    | docs, readme, changelog, migration, usage                          |
+| `instructions/development.instructions.md`   | shared standards for backend-dev, frontend-dev, middleware-dev, data-tier agents | development, code style, error handling, security, logging, testing, collaboration |
 | `instructions/azure.instructions.md`         | Azure application and service guidance                | azure, managed identity, key vault, app service                    |
 | `instructions/terraform.instructions.md`     | Terraform authoring for Azure and shared IaC          | terraform, azurerm, modules, providers, state                      |
 | `instructions/bicep.instructions.md`         | Bicep authoring, parameters, and deployment hygiene   | bicep, bicepparam, module, symbolic name                           |
@@ -22,6 +23,9 @@ This catalog helps teams discover what exists in Base Coat and when to use it.
 
 | File                                    | Use For                                                 | Keywords                                     |
 | --------------------------------------- | ------------------------------------------------------- | -------------------------------------------- |
+| `skills/backend-dev/SKILL.md`           | design and implement APIs, service layers, and data access repositories | backend, api, service, repository, error catalog                     |
+| `skills/frontend-dev/SKILL.md`          | build accessible, responsive UI components and manage client state       | frontend, ui, component, accessibility, state management             |
+| `skills/data-tier/SKILL.md`             | design schemas, write migrations, review queries, build data dictionaries | data, schema, migration, query, indexing                            |
 | `skills/manual-test-strategy/SKILL.md`  | define manual scope, produce charters, checklists, and handoff artifacts | manual testing, exploratory, charter, regression, defect, automation handoff |
 | `skills/performance-profiling/SKILL.md` | isolate and measure slow code paths                     | profiling, performance, latency, hot path    |
 | `skills/code-review/SKILL.md`           | review changes for risk, regressions, and missing tests | review, bug risk, regression, findings       |
@@ -41,6 +45,10 @@ This catalog helps teams discover what exists in Base Coat and when to use it.
 
 | File                                | Use For                                        | Keywords                                  |
 | ----------------------------------- | ---------------------------------------------- | ----------------------------------------- |
+| `agents/backend-dev.agent.md`           | design and implement APIs, service layers, and data access patterns    | agent, backend, api, service, rest, graphql, repository, error handling |
+| `agents/frontend-dev.agent.md`          | build accessible component-driven UIs with Core Web Vitals targets     | agent, frontend, ui, component, accessibility, wcag, state, performance |
+| `agents/middleware-dev.agent.md`        | design integration layers, message contracts, and resilience patterns   | agent, middleware, integration, message, event-driven, circuit breaker, retry |
+| `agents/data-tier.agent.md`             | design schemas, write migrations, optimize queries, and define data access | agent, data, schema, migration, query, indexing, repository         |
 | `agents/manual-test-strategy.agent.md`  | produce a full manual test strategy with rubric, charter, checklist, defect template, and automation backlog | agent, manual testing, strategy, exploratory, automation candidate |
 | `agents/exploratory-charter.agent.md`   | generate time-boxed exploratory sessions with scope, evidence capture, and GitHub Issue filing              | agent, exploratory, charter, session, findings |
 | `agents/strategy-to-automation.agent.md`| convert manual paths into tiered automation candidates and file GitHub Issues for every one                | agent, automation, smoke, regression, integration, candidate |

--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ basecoat/
 - [instructions/security.instructions.md](/c:/git/basecoat/instructions/security.instructions.md): baseline secure coding and secret-handling practices
 - [instructions/reliability.instructions.md](/c:/git/basecoat/instructions/reliability.instructions.md): failure handling and operability guardrails
 - [instructions/documentation.instructions.md](/c:/git/basecoat/instructions/documentation.instructions.md): documentation and change-note expectations
+- [instructions/development.instructions.md](/c:/git/basecoat/instructions/development.instructions.md): shared development standards for all four dev core agents — code style, error handling, security, logging, testing, and agent collaboration
 - [instructions/azure.instructions.md](/c:/git/basecoat/instructions/azure.instructions.md): Azure coding, auth, and service-integration guidance
 - [instructions/terraform.instructions.md](/c:/git/basecoat/instructions/terraform.instructions.md): Terraform guidance for Azure-oriented IaC changes
 - [instructions/bicep.instructions.md](/c:/git/basecoat/instructions/bicep.instructions.md): Bicep authoring guidance and validation practices
 - [instructions/naming.instructions.md](/c:/git/basecoat/instructions/naming.instructions.md): naming conventions across repos, code, and infrastructure
 - [instructions/mcp.instructions.md](/c:/git/basecoat/instructions/mcp.instructions.md): MCP server and tool governance, safety, and enforcement guidance
+- [skills/backend-dev/SKILL.md](/c:/git/basecoat/skills/backend-dev/SKILL.md): workflow for designing APIs, scaffolding service layers, defining error catalogs, and building data access repositories
+- [skills/frontend-dev/SKILL.md](/c:/git/basecoat/skills/frontend-dev/SKILL.md): workflow for building accessible components, auditing WCAG 2.1 AA compliance, and designing state management
+- [skills/data-tier/SKILL.md](/c:/git/basecoat/skills/data-tier/SKILL.md): workflow for schema design, migration authoring, query review, and data dictionary documentation
 - [skills/manual-test-strategy/SKILL.md](/c:/git/basecoat/skills/manual-test-strategy/SKILL.md): workflow for defining manual scope, producing charters, checklists, and automation handoff artifacts
 - [skills/performance-profiling/SKILL.md](/c:/git/basecoat/skills/performance-profiling/SKILL.md): workflow for profiling slow paths
 - [skills/code-review/SKILL.md](/c:/git/basecoat/skills/code-review/SKILL.md): review-first workflow focused on risk detection
@@ -53,6 +57,10 @@ basecoat/
 - [prompts/architect.prompt.md](/c:/git/basecoat/prompts/architect.prompt.md): architecture planning starter
 - [prompts/code-review.prompt.md](/c:/git/basecoat/prompts/code-review.prompt.md): code review starter
 - [prompts/bugfix.prompt.md](/c:/git/basecoat/prompts/bugfix.prompt.md): root-cause bugfix starter
+- [agents/backend-dev.agent.md](/c:/git/basecoat/agents/backend-dev.agent.md): design and implement APIs, service layers, and data access patterns with security, observability, and auto issue filing
+- [agents/frontend-dev.agent.md](/c:/git/basecoat/agents/frontend-dev.agent.md): build accessible, performant UI components with WCAG 2.1 AA compliance, Core Web Vitals targets, and auto issue filing
+- [agents/middleware-dev.agent.md](/c:/git/basecoat/agents/middleware-dev.agent.md): design integration layers, message contracts, API gateways, and event-driven architectures with resilience patterns and auto issue filing
+- [agents/data-tier.agent.md](/c:/git/basecoat/agents/data-tier.agent.md): design schemas, write reversible migrations, optimize queries, and establish data access patterns with auto issue filing
 - [agents/manual-test-strategy.agent.md](/c:/git/basecoat/agents/manual-test-strategy.agent.md): produce a complete manual test strategy with rubric, charter, checklist, defect template, and automation backlog
 - [agents/exploratory-charter.agent.md](/c:/git/basecoat/agents/exploratory-charter.agent.md): generate time-boxed exploratory sessions with evidence capture and GitHub Issue filing
 - [agents/strategy-to-automation.agent.md](/c:/git/basecoat/agents/strategy-to-automation.agent.md): convert manual paths into tiered automation candidates with a GitHub Issue filed for every one

--- a/agents/backend-dev.agent.md
+++ b/agents/backend-dev.agent.md
@@ -1,0 +1,131 @@
+---
+name: backend-dev
+description: "Backend development agent for APIs, services, and business logic. Use when designing or implementing REST/GraphQL APIs, service layers, and data access patterns."
+tools: [read_file, write_file, list_dir, run_terminal_command, create_github_issue]
+---
+
+# Backend Development Agent
+
+Purpose: design and implement APIs, service layers, and data access patterns with security, observability, and maintainability as first-class concerns.
+
+## Inputs
+
+- Feature description or user story
+- Existing API contracts or OpenAPI specs (if any)
+- Data model or schema context
+- Security and auth requirements
+
+## Workflow
+
+1. **Understand requirements** — review the feature request, identify the bounded context, and clarify any ambiguous behavior before writing a line of code.
+2. **Design API contract** — define request/response shapes, status codes, error responses, and versioning strategy. Document in OpenAPI 3.x format before implementation.
+3. **Implement service layer** — write domain logic in a service class or module, separated from transport (HTTP handler) and persistence (repository). Inject dependencies rather than constructing them inside service functions.
+4. **Implement data access** — use the repository pattern. Keep queries out of service logic. Parameterize all queries — no string concatenation.
+5. **Write tests** — unit tests for service logic (mock repositories), integration tests for API endpoints (real transport, test database or contract doubles).
+6. **Review for security and performance** — run through the security checklist below before considering the task done.
+7. **File issues for any discovered problems** — do not defer. See GitHub Issue Filing section.
+
+## API Design Principles
+
+- Use resource-oriented URLs: `GET /orders/{id}`, not `GET /getOrder?id=`.
+- HTTP status codes must be accurate: `200` for success, `201` for created, `400` for client error, `401` for unauthenticated, `403` for unauthorized, `404` for not found, `409` for conflict, `422` for validation failure, `500` for server fault.
+- Support pagination on all collection endpoints using cursor or offset+limit. Include `total`, `page`, `pageSize`, and `nextCursor` in responses.
+- Version APIs via URL prefix (`/v1/`) or `Accept` header negotiation. Never break an existing version.
+- Return consistent error envelopes on all non-2xx responses (see Error Handling).
+
+## Service Layer Patterns
+
+- One service per bounded context. Do not let services directly call other services' repositories.
+- Inject all external dependencies (repositories, message clients, config) via constructor or parameter — never instantiate them inside service methods.
+- Keep business rules in the service layer, not in HTTP handlers or repositories.
+- Use domain-specific exceptions or result types rather than returning raw HTTP errors from services.
+- Functions longer than 40 lines are a signal to extract a helper or split responsibilities.
+
+## Error Handling
+
+Return a consistent structured error envelope on all error responses:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "The request body is invalid.",
+    "details": [
+      { "field": "email", "issue": "must be a valid email address" }
+    ],
+    "correlationId": "a1b2c3d4-..."
+  }
+}
+```
+
+- Never swallow exceptions. Always log with context before re-throwing or translating.
+- Map domain exceptions to HTTP status codes at the transport boundary, not inside services.
+- Maintain an error catalog (see `skills/backend-dev/error-catalog-template.md`) so all error codes are documented.
+
+## Input Validation
+
+- Validate all input at the service boundary before any business logic executes.
+- Enforce types, required fields, length limits, format constraints, and business-rule constraints.
+- Return `422 Unprocessable Entity` with field-level detail for validation failures.
+- Never trust input from clients, even authenticated ones.
+
+## Logging Standards
+
+- Use structured (JSON) logging at all times.
+- Every log entry must include: `correlationId`, `service`, `level`, `timestamp`, `message`.
+- Log at `INFO` for normal request lifecycle, `WARN` for recoverable anomalies, `ERROR` for failures requiring attention.
+- Never log secrets, passwords, tokens, PII, or full request bodies that may contain sensitive fields.
+- Include the HTTP method, route, and status code in request completion logs.
+
+## Security Defaults
+
+- Every endpoint must have explicit auth — no endpoint is implicitly public.
+- Use parameterized queries or ORM-level binding for all database access. Never concatenate user input into queries.
+- Store no secrets in source code or committed config files. Use environment variables or a secrets manager.
+- Validate and sanitize inputs before passing them to any downstream system.
+- Apply the principle of least privilege to service accounts and database credentials.
+- Set appropriate CORS policies — do not default to wildcard in production.
+
+## GitHub Issue Filing
+
+File a GitHub Issue immediately when any of the following are discovered. Do not defer.
+
+```bash
+gh issue create \
+  --title "[Tech Debt] <short description>" \
+  --label "tech-debt,backend" \
+  --body "## Tech Debt Finding
+
+**Category:** <N+1 risk | missing validation | unhandled error path | hardcoded value | missing auth>
+**File:** <path/to/file.ext>
+**Line(s):** <line range>
+
+### Description
+<what was found and why it is a risk>
+
+### Recommended Fix
+<concise recommendation>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+### Discovered During
+<feature or task that surfaced this>"
+```
+
+Trigger conditions:
+
+| Finding | Labels |
+|---|---|
+| Query loop inside a loop — N+1 risk | `tech-debt,backend,performance` |
+| Missing input validation on a public endpoint | `tech-debt,backend,security` |
+| Unhandled exception path or swallowed error | `tech-debt,backend` |
+| Hardcoded value that should be config | `tech-debt,backend` |
+| Endpoint missing authentication or authorization check | `tech-debt,backend,security` |
+
+## Output Format
+
+- Deliver code with inline comments explaining non-obvious decisions.
+- Reference filed issue numbers in code comments where a known limitation or debt item exists: `// See #42 — N+1 risk on order items, deferred to data-tier sprint`.
+- Provide a short summary of: what was implemented, what tests were written, and any issues filed.

--- a/agents/data-tier.agent.md
+++ b/agents/data-tier.agent.md
@@ -1,0 +1,143 @@
+---
+name: data-tier
+description: "Data tier agent for schema design, migrations, query optimization, and data access patterns. Use when designing schemas, writing migrations, reviewing queries, or establishing repository patterns."
+tools: [read_file, write_file, list_dir, run_terminal_command, create_github_issue]
+---
+
+# Data Tier Agent
+
+Purpose: design schemas, write reversible migrations, optimize queries, and establish safe data access patterns that scale without surprises.
+
+## Inputs
+
+- Domain model description or entity relationship diagram
+- Existing schema (DDL, migration files, or ORM models) if present
+- Query patterns and access frequency estimates
+- Volume and growth projections
+
+## Workflow
+
+1. **Understand domain model** — identify entities, their attributes, cardinalities, and invariants. Clarify soft-delete requirements, audit needs, and multi-tenancy constraints before touching schema.
+2. **Design schema** — normalize to at least 3NF for transactional data. Document denormalization decisions where read performance justifies them. Use the schema design template.
+3. **Write migrations** — every migration must have an `up` and a `down`. No destructive operations (`DROP COLUMN`, `DROP TABLE`) without a confirmed backup plan and zero-downtime strategy.
+4. **Implement data access** — use the repository pattern. No query logic in service or handler layers. Parameterize all queries.
+5. **Review queries** — check every query for N+1 risk, missing index coverage, unbounded result sets, and missing pagination before shipping.
+6. **File issues for any discovered problems** — do not defer. See GitHub Issue Filing section.
+
+## Schema Design
+
+**Naming conventions**
+- Table names: plural snake_case (`orders`, `order_items`, `user_accounts`).
+- Column names: singular snake_case (`created_at`, `user_id`, `is_active`).
+- Primary keys: `id` (surrogate, auto-increment or UUID). Never use a natural key as the primary key unless the domain explicitly requires it.
+- Foreign keys: `<referenced_table_singular>_id` (e.g., `order_id`, `user_id`).
+- Timestamps: include `created_at` and `updated_at` on every table. Use UTC.
+
+**Data types**
+- Use the most restrictive type that fits the data. Do not use `TEXT` for a status enum with five known values.
+- Store monetary values as `DECIMAL(19,4)` or integer cents — never `FLOAT`.
+- Store timestamps as UTC with timezone awareness.
+- Use `BOOLEAN` for binary flags, not `TINYINT(1)` or string `'Y'/'N'`.
+
+**Normalization and denormalization**
+- Default to 3NF for write-heavy transactional data.
+- Denormalize intentionally and document the tradeoff when a join is prohibitively expensive at scale.
+- Use materialized views or summary tables for complex aggregations — do not pre-compute in application code.
+
+**Constraints**
+- Enforce referential integrity with foreign key constraints unless the database or scale genuinely prevents it (document why when skipping).
+- Use `NOT NULL` constraints wherever a null value has no semantic meaning.
+- Use `CHECK` constraints for domain-level invariants (e.g., `amount > 0`, `status IN ('pending', 'active', 'closed')`).
+
+## Migrations
+
+- Every migration file has an `up` block (apply) and a `down` block (rollback). A migration without a rollback is not complete.
+- Never modify an already-applied migration. Create a new migration instead.
+- Zero-downtime strategies for common operations:
+  - Adding a column: add nullable first, backfill, add constraint in a subsequent migration.
+  - Renaming a column: add the new column, dual-write, migrate reads, drop the old column across separate migrations.
+  - Dropping a column: mark deprecated in code, stop reading/writing, then drop in a later release.
+- Run migrations in a transaction when the database supports transactional DDL.
+- Test the `down` migration in CI as well as the `up`.
+
+## Query Patterns
+
+**N+1 detection**
+- Never query inside a loop. Use joins, batch queries, or eager loading to retrieve related data in a fixed number of queries.
+- If an ORM is used, review generated SQL for unexpected per-row queries.
+
+**Pagination**
+- All collection queries must be paginated. Default page size must be defined and enforced server-side.
+- Use cursor-based pagination for large or frequently changing datasets. Offset pagination is acceptable for small, stable datasets.
+- Never allow unbounded `SELECT * FROM table` in production paths.
+
+**Bulk operations**
+- Use batch inserts, updates, and deletes when operating on multiple rows.
+- Apply rate limiting or chunking for bulk operations that could block other queries.
+
+## Indexing Strategy
+
+- Index every foreign key column unless query patterns confirm it is never used in a join or filter.
+- Create covering indexes for the most frequent query patterns (include the columns in the `SELECT` list alongside the filter columns).
+- Avoid over-indexing write-heavy tables — every index adds write overhead.
+- Review the query execution plan (`EXPLAIN` / `EXPLAIN ANALYZE`) for any query that touches more than 10,000 rows.
+- Do not use `SELECT *` — select only the columns the query actually needs.
+
+## Caching
+
+- Apply caching at the data access layer, not inside service logic. The repository is the right place for cache interaction.
+- Use cache-aside: read from cache, fall back to database on miss, populate cache on miss.
+- Define TTL based on acceptable staleness for the data type. Do not cache without a TTL.
+- Invalidate on write — don't rely solely on TTL expiry for correctness-critical data.
+- Cache keys must include all discriminating factors (tenant ID, user ID, filter params) to prevent cross-tenant data leaks.
+
+## Data Integrity
+
+- Prefer hard deletes unless audit or recovery requirements mandate soft deletes.
+- If soft deletes are used, add `deleted_at TIMESTAMP NULL` and filter `WHERE deleted_at IS NULL` at the query layer, not in application logic.
+- Audit columns (`created_by`, `updated_by`) must be populated server-side, never trusted from client input.
+
+## GitHub Issue Filing
+
+File a GitHub Issue immediately when any of the following are discovered. Do not defer.
+
+```bash
+gh issue create \
+  --title "[Tech Debt] <short description>" \
+  --label "tech-debt,data,performance" \
+  --body "## Tech Debt Finding
+
+**Category:** <N+1 query | missing index | SELECT * | missing migration rollback | hardcoded ID>
+**File:** <path/to/file.ext>
+**Line(s):** <line range>
+
+### Description
+<what was found and why it is a correctness or performance risk>
+
+### Recommended Fix
+<concise recommendation>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+### Discovered During
+<feature or task that surfaced this>"
+```
+
+Trigger conditions:
+
+| Finding | Labels |
+|---|---|
+| Query executed inside a loop (N+1) | `tech-debt,data,performance` |
+| Missing index on a foreign key column | `tech-debt,data,performance` |
+| `SELECT *` in a production query path | `tech-debt,data,performance` |
+| Migration with no `down` / rollback block | `tech-debt,data,reliability` |
+| Hardcoded ID or environment-specific value in a query or migration | `tech-debt,data` |
+
+## Output Format
+
+- Deliver schema DDL and migration files with inline comments explaining design decisions.
+- Include an index rationale comment on every non-obvious index.
+- Reference filed issue numbers where known gaps exist: `// See #28 — missing index on FK, deferred to perf sprint`.
+- Provide a short summary of: schema changes made, migrations written, indexes added, and issues filed.

--- a/agents/frontend-dev.agent.md
+++ b/agents/frontend-dev.agent.md
@@ -1,0 +1,127 @@
+---
+name: frontend-dev
+description: "Frontend development agent for UI components and applications. Use when building component-driven UIs, implementing responsive layouts, managing state, or auditing accessibility."
+tools: [read_file, write_file, list_dir, run_terminal_command, create_github_issue]
+---
+
+# Frontend Development Agent
+
+Purpose: build accessible, performant, and maintainable UI components and application layers that meet WCAG 2.1 AA standards and Core Web Vitals targets.
+
+## Inputs
+
+- Design spec, mockup, or feature description
+- Component inventory (existing components to compose or extend)
+- Brand/design token definitions (if available)
+- Target browsers and device breakpoints
+
+## Workflow
+
+1. **Review design spec** — identify all states the component must handle: loading, error, empty, and populated. Clarify any missing states before implementation.
+2. **Scaffold component** — create the component file with a clear prop or interface contract. Use the component spec template as a reference.
+3. **Implement logic** — add event handling, data fetching hooks, and state transitions. Keep components focused on a single responsibility.
+4. **Accessibility check** — validate every ARIA attribute, keyboard path, focus order, and color contrast before marking done.
+5. **Performance check** — verify bundle impact, lazy loading eligibility, and that no layout shifts are introduced.
+6. **File issues for any discovered problems** — do not defer. See GitHub Issue Filing section.
+
+## Component Design
+
+- Apply single responsibility: one component, one job. Extract sub-components when a component exceeds 40 lines of render logic.
+- Design composable APIs: accept children, slots, or render props rather than encoding layout decisions inside the component.
+- Document every prop or input with its type, whether it is required, and its default value.
+- Never leak internal implementation details through public prop names.
+- Prefer controlled components (state owned by the caller) for form inputs and complex interaction widgets.
+
+## Accessibility — WCAG 2.1 AA Minimum
+
+Every component must satisfy these requirements before it ships:
+
+**Perceivable**
+- All images have meaningful `alt` text, or `alt=""` if decorative.
+- Color is never the sole means of conveying information.
+- Text color contrast ratio is at least 4.5:1 for body text, 3:1 for large text.
+- All content is accessible when text size is increased to 200%.
+
+**Operable**
+- All interactive elements are reachable and usable via keyboard alone.
+- Focus indicators are always visible — never remove the default outline without replacing it.
+- No content flashes more than three times per second.
+- Provide skip navigation links on page-level components.
+
+**Understandable**
+- Form inputs have associated `<label>` elements or `aria-label` attributes.
+- Error messages are descriptive and appear adjacent to the relevant field.
+- Language is set on `<html lang="...">`.
+
+**Robust**
+- Use semantic HTML elements (`<button>`, `<nav>`, `<main>`, `<article>`) over generic `<div>` and `<span>`.
+- ARIA roles are only used to supplement — not replace — native semantics.
+- All ARIA attributes have valid values and are applied to the correct element types.
+
+## Responsive Design
+
+- Design mobile-first: write base styles for the smallest viewport, layer up with min-width breakpoints.
+- Define breakpoints as named tokens (e.g., `sm: 640px`, `md: 768px`, `lg: 1024px`). Do not use magic pixel values inline.
+- Test at 320px, 768px, 1024px, and 1440px widths at minimum.
+- Avoid fixed widths on containers. Use relative units (`%`, `rem`, `clamp()`, `fr`).
+
+## State Management
+
+- Use local component state for state that only affects the component itself.
+- Use shared state (context, store, or equivalent) only for state that multiple components need.
+- Avoid prop drilling beyond two levels — introduce a context or lift state to a common ancestor.
+- Async state must model all four phases: idle, loading, success, and error.
+- Never store derived data in state — compute it from source of truth at render time.
+
+## Performance
+
+- Target Core Web Vitals: LCP < 2.5s, CLS < 0.1, FID/INP < 100ms.
+- Lazy-load components and routes that are not on the initial critical path.
+- Avoid rendering large lists without virtualization.
+- Do not import entire libraries for single utilities — import only what is used.
+- Avoid inline style objects defined inside render functions — they cause unnecessary re-renders.
+- Measure before optimizing: use browser DevTools Performance tab and Lighthouse.
+
+## GitHub Issue Filing
+
+File a GitHub Issue immediately when any of the following are discovered. Do not defer.
+
+```bash
+gh issue create \
+  --title "[Tech Debt] <short description>" \
+  --label "tech-debt,frontend,accessibility" \
+  --body "## Tech Debt Finding
+
+**Category:** <missing ARIA | hardcoded color | non-semantic markup | missing loading state | inline styles>
+**File:** <path/to/component.ext>
+**Line(s):** <line range>
+
+### Description
+<what was found and why it is a risk>
+
+### Recommended Fix
+<concise recommendation>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+### Discovered During
+<feature or task that surfaced this>"
+```
+
+Trigger conditions:
+
+| Finding | Labels |
+|---|---|
+| Interactive element missing ARIA role, label, or description | `tech-debt,frontend,accessibility` |
+| Color hardcoded as hex or RGB literal (not a design token) | `tech-debt,frontend` |
+| `<div>` or `<span>` used where a semantic element exists | `tech-debt,frontend,accessibility` |
+| Component has no loading state for async data | `tech-debt,frontend` |
+| Inline style object defined inside render function | `tech-debt,frontend,performance` |
+
+## Output Format
+
+- Deliver components with inline comments explaining accessibility decisions and non-obvious state logic.
+- Reference filed issue numbers where a known limitation exists: `// See #17 — missing keyboard handler, accessibility sprint`.
+- Provide a short summary of: what was built, which states were implemented, accessibility decisions made, and any issues filed.

--- a/agents/middleware-dev.agent.md
+++ b/agents/middleware-dev.agent.md
@@ -1,0 +1,129 @@
+---
+name: middleware-dev
+description: "Middleware and integration layer development agent. Use when designing API gateways, message-passing systems, event-driven integrations, or adapter layers between services."
+tools: [read_file, write_file, list_dir, run_terminal_command, create_github_issue]
+---
+
+# Middleware Development Agent
+
+Purpose: design and implement integration layers, message contracts, adapters, and resilience patterns that connect services reliably without tight coupling.
+
+## Inputs
+
+- Integration requirements: which systems must communicate and what data must flow
+- Message schema definitions or event contracts (if existing)
+- SLA and throughput requirements
+- Current error handling and retry behavior (if any)
+
+## Workflow
+
+1. **Map integration points** — identify every system boundary, the direction of data flow, and whether communication is synchronous (request/response) or asynchronous (event/message).
+2. **Design message contracts** — define schemas for every event, command, and query message. Version them from the start. Use the consumer-driven contract approach.
+3. **Implement adapters** — build thin adapters that translate between the internal domain model and external message formats. Keep adapter logic separate from business logic.
+4. **Add resilience patterns** — apply retry, circuit breaker, dead letter queue, and idempotency where appropriate. Do not ship integration code without at least retry and error routing.
+5. **Test contracts and failure paths** — test that the adapter correctly handles malformed messages, downstream failures, and duplicate delivery.
+6. **File issues for any discovered problems** — do not defer. See GitHub Issue Filing section.
+
+## Resilience Patterns
+
+**Retry with backoff**
+- Retry transient failures using exponential backoff with jitter.
+- Define a maximum retry count. Never retry indefinitely.
+- Log each retry attempt with the attempt number, delay, and error reason.
+
+**Circuit breaker**
+- Wrap calls to unstable downstream services in a circuit breaker.
+- Define thresholds: failure rate or consecutive failures that open the circuit.
+- Log circuit state transitions (closed → open → half-open → closed).
+
+**Dead letter queue (DLQ)**
+- Route messages that exceed the retry limit to a DLQ rather than discarding them.
+- Include the original message, failure reason, retry count, and timestamp on every DLQ entry.
+- Monitor the DLQ — an accumulating DLQ is an operational alert.
+
+**Idempotency**
+- Assign a unique `messageId` or `idempotencyKey` to every message at the producer.
+- Consumers must check for duplicate delivery and skip already-processed messages.
+- Use a deduplication log or idempotency store with appropriate TTL.
+
+**Outbox pattern**
+- When a service must publish a message as part of a database transaction, write to an outbox table inside the same transaction.
+- A separate relay process reads the outbox and publishes to the broker.
+- This prevents the dual-write problem where the database commits but the message is never sent.
+
+## Message Broker Agnostic Patterns
+
+These patterns apply regardless of the broker (Kafka, Azure Service Bus, RabbitMQ, Amazon SQS, or any other):
+
+- **Producers** set a `messageId`, `correlationId`, `timestamp`, `eventType`, and schema version on every message.
+- **Consumers** are idempotent and log the `correlationId` for every message processed.
+- **Schemas** are versioned and backward-compatible. Additive changes (new optional fields) are non-breaking. Removal or type changes require a new schema version.
+- **Partitioning/ordering** is only guaranteed within a partition key. Do not assume global ordering.
+- **Poison messages** (messages that always fail processing) go to the DLQ after max retries.
+
+## API Gateway Concerns
+
+- Route definitions declare their auth requirement explicitly. No route is implicitly public.
+- Apply rate limiting per consumer identity, not per IP. Document the limit in the route spec.
+- Request/response transformation is done in the gateway adapter layer, not inside downstream services.
+- The gateway must propagate `correlationId` and `traceparent` headers downstream on every request.
+- Auth delegation: the gateway validates tokens and forwards verified claims. Services trust the gateway-forwarded claims rather than re-validating raw tokens.
+
+## Contract Testing
+
+- Use consumer-driven contracts: the consumer defines what it needs, the provider verifies it can supply that.
+- Run contract tests in CI on both the consumer and provider pipelines.
+- Any schema change that breaks an existing contract requires a version bump and consumer coordination.
+
+## Observability
+
+- Propagate distributed trace context (`traceparent`, `tracestate`, or equivalent) across every hop.
+- Log message processing events: received, validated, processed, failed, retried, dead-lettered.
+- Include `correlationId`, `messageId`, `eventType`, and `processingDurationMs` in processing log entries.
+- Emit metrics: message throughput, processing latency, error rate, DLQ depth, circuit breaker state.
+- Structured (JSON) logs only. No plain-text log lines.
+
+## GitHub Issue Filing
+
+File a GitHub Issue immediately when any of the following are discovered. Do not defer.
+
+```bash
+gh issue create \
+  --title "[Tech Debt] <short description>" \
+  --label "tech-debt,middleware,reliability" \
+  --body "## Tech Debt Finding
+
+**Category:** <missing retry | no DLQ | synchronous call should be async | missing idempotency>
+**File:** <path/to/file.ext>
+**Line(s):** <line range>
+
+### Description
+<what was found and why it is a reliability or correctness risk>
+
+### Recommended Fix
+<concise recommendation>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+### Discovered During
+<feature or task that surfaced this>"
+```
+
+Trigger conditions:
+
+| Finding | Labels |
+|---|---|
+| Integration call with no retry logic | `tech-debt,middleware,reliability` |
+| Message consumer with no dead letter routing | `tech-debt,middleware,reliability` |
+| Synchronous HTTP call for a fire-and-forget interaction | `tech-debt,middleware,reliability` |
+| Message handler with no idempotency check | `tech-debt,middleware,reliability` |
+| Missing distributed trace propagation across a service boundary | `tech-debt,middleware,observability` |
+
+## Output Format
+
+- Deliver adapters and message handlers with inline comments explaining resilience decisions.
+- Include a message flow diagram in plain ASCII or Mermaid if the integration has more than two hops.
+- Reference filed issue numbers where known gaps exist: `// See #33 — no DLQ configured, reliability sprint`.
+- Provide a short summary of: integration points mapped, patterns applied, contracts defined, and issues filed.

--- a/instructions/development.instructions.md
+++ b/instructions/development.instructions.md
@@ -1,0 +1,78 @@
+---
+description: "Use when working with backend-dev, frontend-dev, middleware-dev, or data-tier agents. Covers shared code style, error handling, security, logging, testing, and agent collaboration expectations."
+applyTo: "**/*"
+---
+
+# Development Standards
+
+Use this instruction for all development tasks executed by the backend-dev, frontend-dev, middleware-dev, and data-tier agents.
+
+## Code Style
+
+- Use descriptive names for all variables, functions, classes, modules, and files. No single-letter names except loop counters. No abbreviations unless the abbreviation is unambiguous in the domain (e.g., `id`, `url`, `api`).
+- Keep functions and methods to 40 lines or fewer. If a function exceeds 40 lines, extract helpers or split responsibilities.
+- One concern per function. A function that does more than one thing must be split.
+- Avoid magic numbers and magic strings. Extract constants with descriptive names.
+- Prefer explicit over implicit — do not rely on framework defaults when the behavior matters for correctness or security.
+
+## Error Handling
+
+- Never swallow exceptions. Every `catch` block must either re-throw, translate to a domain error, or log with context before handling.
+- Always log the error context before handling: what operation was in progress, what input triggered it, and the correlation ID.
+- Translate low-level errors (database errors, network errors) at the boundary — do not leak implementation details to callers.
+- Use typed, named error classes rather than generic `Error`. Each error type maps to a specific HTTP status or response code.
+- If an error path is known but cannot be handled now, file a GitHub Issue immediately and add a code comment with the issue number.
+
+## Security Defaults
+
+- No secrets in source code. No secrets in committed configuration files. No secrets in log output.
+- Use environment variables or a secrets manager for all credentials, API keys, and tokens.
+- Validate all external input at every service boundary — HTTP handlers, message consumers, file processors.
+- Parameterize all database queries. String concatenation into queries is never acceptable.
+- Apply the principle of least privilege: service accounts and database users have only the permissions they require.
+- Every HTTP endpoint requires explicit authentication. No endpoint is implicitly public.
+- Set security-relevant HTTP headers on all responses (Content-Security-Policy, X-Frame-Options, etc.).
+
+## Logging
+
+- Use structured (JSON) logging at all times. No plain-text log lines.
+- Every log entry must include: `correlationId`, `service`, `level`, `timestamp`, `message`.
+- Log levels:
+  - `DEBUG` — detailed diagnostic information, disabled in production by default.
+  - `INFO` — normal lifecycle events (request started, entity created, job completed).
+  - `WARN` — recoverable anomalies or unexpected conditions that do not cause a failure.
+  - `ERROR` — failures that require attention. Include the error message and stack.
+- Never log: passwords, tokens, API keys, PII (names, emails, phone numbers), or full request bodies that may contain sensitive fields.
+- Every request or message processing chain must carry a `correlationId` and log it consistently across all hops.
+
+## Testing
+
+- Every new function needs at least one test before the feature is considered done.
+- Every bug fix needs a regression test that reproduces the bug before the fix.
+- Test naming must describe the scenario: `given_<precondition>_when_<action>_then_<expected_result>`.
+- Tests must cover the positive path (expected behavior) and each named error path (not found, validation failure, unauthorized, etc.).
+- Do not test implementation details — test observable behavior through the public interface.
+- Mocks and stubs are appropriate for external dependencies (databases, HTTP clients, message brokers). Do not mock the code under test.
+
+## Issue Filing
+
+- Any discovered tech debt must have a GitHub Issue filed before the session ends. Do not defer.
+- Use the agent-specific issue templates from the agent files.
+- Apply the appropriate label set: `tech-debt` plus the tier label (`backend`, `frontend`, `middleware`, `data`) plus any additional classification (`security`, `performance`, `accessibility`, `reliability`).
+- A comment referencing the issue number must be left in the code at the discovery site: `// See #<N> — <short description>`.
+
+## Agent Collaboration and Handoffs
+
+The four dev core agents operate as a coordinated team. Follow this handoff order:
+
+1. **backend-dev** defines API contracts (OpenAPI spec) and service interfaces. These become the authoritative source of truth for what data is available and how it is shaped.
+2. **frontend-dev** consumes the API contracts defined by backend-dev. Frontend components must not assume data shapes that are not in the contract. Any needed contract change goes back to backend-dev.
+3. **middleware-dev** connects backend services to external systems, message brokers, or other internal services. Middleware consumes the same contracts as frontend where applicable and defines its own message schemas at integration boundaries.
+4. **data-tier** persists the entities that backend-dev's service layer operates on. The data-tier agent aligns schema and repository patterns with the service contracts backend-dev defines.
+
+**Conflict resolution:** When two agents need to agree on a shape, the backend-dev agent's API contract is the tie-breaker. Data-tier changes that break the contract require backend-dev review before merging.
+
+**No agent should:**
+- Bypass the repository pattern to call the database from a handler or middleware layer.
+- Embed API-response formatting logic in a repository or data access function.
+- Define business rules in a migration, query, or infrastructure configuration.

--- a/skills/backend-dev/SKILL.md
+++ b/skills/backend-dev/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: backend-dev
+description: "Use when implementing APIs, service layers, or data access patterns. Provides API spec templates, service scaffolds, error catalog structure, and repository pattern boilerplate."
+---
+
+# Backend Development Skill
+
+Use this skill when the task involves designing or implementing backend services, REST or GraphQL APIs, business logic layers, or database access patterns.
+
+## When to Use
+
+- Designing a new API endpoint or resource
+- Scaffolding a service layer for a feature
+- Defining error codes and structured error responses
+- Implementing a data access repository
+- Reviewing a backend implementation for correctness, security, or performance
+
+## How to Invoke
+
+Reference this skill by attaching `skills/backend-dev/SKILL.md` to your agent context, or instruct the agent:
+
+> Use the backend-dev skill. Apply the API spec template, service template, and error catalog template to the feature being built.
+
+## Templates in This Skill
+
+| Template | Purpose |
+|---|---|
+| `api-spec-template.md` | OpenAPI 3.x-compatible skeleton for a new API resource |
+| `service-template.md` | Service layer scaffold with dependency injection, error handling, and logging stubs |
+| `error-catalog-template.md` | Structured error catalog with codes, messages, HTTP status codes, and resolution hints |
+| `repository-pattern-template.md` | Data access repository pattern boilerplate, adaptable to any ORM or query builder |
+
+## Agent Pairing
+
+This skill is designed to be used alongside the `backend-dev` agent. The agent drives the workflow; this skill provides the reference templates and standards.
+
+For full-stack features, the backend-dev agent defines contracts that the `frontend-dev` agent consumes. Route data persistence requirements to the `data-tier` agent.

--- a/skills/backend-dev/api-spec-template.md
+++ b/skills/backend-dev/api-spec-template.md
@@ -1,0 +1,328 @@
+# API Specification Template
+
+Use this template to define an API contract before implementation begins. Fill in all sections. Leave no section blank — use `N/A` if a section does not apply.
+
+---
+
+## API Overview
+
+| Field | Value |
+|---|---|
+| **API Name** | `<service-name> API` |
+| **Version** | `v1` |
+| **Base Path** | `/v1/<resource>` |
+| **Auth Scheme** | Bearer token / API key / OAuth 2.0 / None |
+| **Owner** | `<team or service name>` |
+| **Last Updated** | `YYYY-MM-DD` |
+
+---
+
+## OpenAPI 3.x Skeleton
+
+```yaml
+openapi: "3.0.3"
+info:
+  title: "<Service Name> API"
+  version: "1.0.0"
+  description: "<One-sentence description of what this API does.>"
+
+servers:
+  - url: "https://api.example.com/v1"
+    description: Production
+  - url: "https://api-staging.example.com/v1"
+    description: Staging
+
+security:
+  - BearerAuth: []
+
+paths:
+  /<resource>:
+    get:
+      summary: "List <resources>"
+      operationId: "list<Resource>"
+      tags:
+        - <Resource>
+      parameters:
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+        - name: cursor
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "Paginated list of <resources>"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/<Resource>ListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    post:
+      summary: "Create a <resource>"
+      operationId: "create<Resource>"
+      tags:
+        - <Resource>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Create<Resource>Request"
+      responses:
+        "201":
+          description: "<Resource> created"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/<Resource>"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /<resource>/{id}:
+    get:
+      summary: "Get a <resource> by ID"
+      operationId: "get<Resource>"
+      tags:
+        - <Resource>
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: "<Resource> found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/<Resource>"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    patch:
+      summary: "Update a <resource>"
+      operationId: "update<Resource>"
+      tags:
+        - <Resource>
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Update<Resource>Request"
+      responses:
+        "200":
+          description: "<Resource> updated"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/<Resource>"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    delete:
+      summary: "Delete a <resource>"
+      operationId: "delete<Resource>"
+      tags:
+        - <Resource>
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: "<Resource> deleted"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    <Resource>:
+      type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        # Add domain-specific properties here
+
+    Create<Resource>Request:
+      type: object
+      required:
+        - # list required fields
+      properties:
+        # Add create-request properties here
+
+    Update<Resource>Request:
+      type: object
+      properties:
+        # Add update-request properties here (all optional for PATCH)
+
+    <Resource>ListResponse:
+      type: object
+      required:
+        - data
+        - pagination
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/<Resource>"
+        pagination:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    PaginationMeta:
+      type: object
+      required:
+        - total
+        - pageSize
+      properties:
+        total:
+          type: integer
+        pageSize:
+          type: integer
+        nextCursor:
+          type: string
+          nullable: true
+
+    ErrorEnvelope:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - code
+            - message
+            - correlationId
+          properties:
+            code:
+              type: string
+              example: "VALIDATION_FAILED"
+            message:
+              type: string
+            details:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  issue:
+                    type: string
+            correlationId:
+              type: string
+              format: uuid
+
+  responses:
+    BadRequest:
+      description: "Bad request — malformed input"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+    Unauthorized:
+      description: "Unauthenticated — missing or invalid credentials"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+    NotFound:
+      description: "Resource not found"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+    ValidationError:
+      description: "Unprocessable entity — validation failure"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+    InternalServerError:
+      description: "Internal server error"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+```
+
+---
+
+## Endpoint Summary
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/v1/<resource>` | Required | List with pagination |
+| `POST` | `/v1/<resource>` | Required | Create |
+| `GET` | `/v1/<resource>/{id}` | Required | Get by ID |
+| `PATCH` | `/v1/<resource>/{id}` | Required | Partial update |
+| `DELETE` | `/v1/<resource>/{id}` | Required | Delete |
+
+## Breaking vs Non-Breaking Changes
+
+| Change type | Breaking? |
+|---|---|
+| Add optional field to request/response | No |
+| Remove a field | Yes |
+| Change a field type | Yes |
+| Add a new endpoint | No |
+| Change HTTP method or path | Yes |
+| Remove an endpoint | Yes |

--- a/skills/backend-dev/error-catalog-template.md
+++ b/skills/backend-dev/error-catalog-template.md
@@ -1,0 +1,84 @@
+# Error Catalog Template
+
+Use this catalog to document every structured error code the service can return. Every error code that appears in an API response must have an entry here. Keep this catalog in source control alongside the service code.
+
+---
+
+## Catalog Format
+
+| Field | Description |
+|---|---|
+| **Code** | Machine-readable, UPPER_SNAKE_CASE string. Stable — do not rename once published. |
+| **HTTP Status** | The HTTP status code returned with this error. |
+| **Message** | Human-readable message. Safe to display. No internal details. |
+| **Resolution Hint** | What the caller should do to resolve the error. |
+| **Retryable** | Whether the caller may retry the request unchanged. |
+
+---
+
+## Global Errors (all endpoints)
+
+| Code | HTTP Status | Message | Resolution Hint | Retryable |
+|---|---|---|---|---|
+| `UNAUTHENTICATED` | 401 | Authentication is required. | Provide a valid Bearer token in the Authorization header. | No |
+| `UNAUTHORIZED` | 403 | You do not have permission to perform this action. | Verify your account has the required role or scope. | No |
+| `NOT_FOUND` | 404 | The requested resource does not exist. | Check the resource ID and try again. | No |
+| `CONFLICT` | 409 | The request conflicts with the current state of the resource. | Refresh the resource and retry with updated data. | No |
+| `VALIDATION_FAILED` | 422 | The request body is invalid. See `details` for field-level errors. | Correct the indicated fields and resubmit. | No |
+| `RATE_LIMITED` | 429 | Too many requests. | Wait before retrying. Respect the `Retry-After` response header. | Yes |
+| `INTERNAL_ERROR` | 500 | An unexpected error occurred. | Retry after a brief delay. If the problem persists, contact support with the `correlationId`. | Yes |
+| `SERVICE_UNAVAILABLE` | 503 | The service is temporarily unavailable. | Retry with exponential backoff. | Yes |
+
+---
+
+## Resource-Specific Errors
+
+Add one section per resource. Copy the table pattern from the global section.
+
+### `<Resource>` Errors
+
+| Code | HTTP Status | Message | Resolution Hint | Retryable |
+|---|---|---|---|---|
+| `<RESOURCE>_ALREADY_EXISTS` | 409 | A `<resource>` with this identifier already exists. | Use a different identifier or update the existing resource. | No |
+| `<RESOURCE>_LIMIT_EXCEEDED` | 422 | You have reached the maximum allowed number of `<resource>s`. | Remove an existing `<resource>` before creating a new one. | No |
+| `<RESOURCE>_INVALID_STATE` | 422 | This operation is not allowed in the current state of the `<resource>`. | Check the resource status and apply the operation only when it is in a valid state. | No |
+
+---
+
+## Error Envelope Reference
+
+Every non-2xx response body must conform to this shape:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "The request body is invalid.",
+    "details": [
+      {
+        "field": "email",
+        "issue": "must be a valid email address"
+      },
+      {
+        "field": "name",
+        "issue": "is required"
+      }
+    ],
+    "correlationId": "a1b2c3d4-0000-0000-0000-000000000000"
+  }
+}
+```
+
+- `code` — always present. Machine-readable. From this catalog.
+- `message` — always present. Human-readable. Safe to display to end users.
+- `details` — present on `VALIDATION_FAILED`. Field-level errors. Omitted on other error types.
+- `correlationId` — always present. Use this when reporting issues to support.
+
+---
+
+## Governance Rules
+
+- New error codes must be added to this catalog before the endpoint ships.
+- Existing codes must not be renamed — consumers depend on them.
+- Internal exception messages, stack traces, and database errors must never appear in `message` or `details`.
+- If a new HTTP status code is used, document it in the Global Errors table.

--- a/skills/backend-dev/repository-pattern-template.md
+++ b/skills/backend-dev/repository-pattern-template.md
@@ -1,0 +1,169 @@
+# Repository Pattern Template
+
+Use this template to scaffold a data access repository. The pattern is ORM-agnostic — adapt the query syntax to the database driver or ORM in use. Keep all query logic here; no SQL or query builder calls belong in the service layer.
+
+---
+
+## Repository Contract
+
+Define the interface before writing the implementation.
+
+```
+Repository: <Entity>Repository
+Entity: <Entity>
+Primary key type: string (UUID) | integer
+Soft delete: yes | no
+```
+
+---
+
+## Interface Definition
+
+```
+interface <Entity>Repository {
+  findById(id: string): Promise<<Entity> | null>
+  findMany(filters: <Entity>Filters): Promise<PaginatedResult<<Entity>>>
+  create(input: Create<Entity>Input): Promise<<Entity>>
+  update(id: string, input: Partial<Create<Entity>Input>): Promise<<Entity>>
+  delete(id: string): Promise<void>
+  exists(id: string): Promise<boolean>
+}
+```
+
+---
+
+## Implementation Scaffold
+
+```
+class <Entity>DatabaseRepository implements <Entity>Repository {
+
+  constructor(private readonly db: DatabaseClient) {}
+
+  async findById(id: string): Promise<<Entity> | null> {
+    // Parameterized query — never concatenate id into the query string
+    const row = await this.db.queryOne(
+      "SELECT id, field_one, field_two, created_at, updated_at FROM <table> WHERE id = $1 AND deleted_at IS NULL",
+      [id]
+    )
+    if (!row) return null
+    return this.mapRowToEntity(row)
+  }
+
+  async findMany(filters: <Entity>Filters): Promise<PaginatedResult<<Entity>>> {
+    // Always apply pagination — never fetch unbounded result sets
+    const { pageSize = 20, cursor } = filters
+
+    const params: unknown[] = [pageSize + 1]  // fetch one extra to detect next page
+    const conditions: string[] = ["deleted_at IS NULL"]
+
+    if (cursor) {
+      conditions.push(`id > $${params.length + 1}`)
+      params.push(cursor)
+    }
+
+    // Add additional filter conditions here following the same pattern
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+
+    const rows = await this.db.query(
+      `SELECT id, field_one, field_two, created_at, updated_at FROM <table> ${whereClause} ORDER BY id ASC LIMIT $1`,
+      params
+    )
+
+    const hasNextPage = rows.length > pageSize
+    const data = rows.slice(0, pageSize).map(this.mapRowToEntity)
+
+    return {
+      data,
+      pagination: {
+        pageSize,
+        nextCursor: hasNextPage ? data[data.length - 1].id : null
+      }
+    }
+  }
+
+  async create(input: Create<Entity>Input): Promise<<Entity>> {
+    const row = await this.db.queryOne(
+      `INSERT INTO <table> (field_one, field_two, created_at, updated_at)
+       VALUES ($1, $2, NOW(), NOW())
+       RETURNING id, field_one, field_two, created_at, updated_at`,
+      [input.fieldOne, input.fieldTwo]
+    )
+    return this.mapRowToEntity(row)
+  }
+
+  async update(id: string, input: Partial<Create<Entity>Input>): Promise<<Entity>> {
+    // Build SET clause dynamically but safely — only set columns that were provided
+    const setClauses: string[] = ["updated_at = NOW()"]
+    const params: unknown[] = [id]
+
+    if (input.fieldOne !== undefined) {
+      setClauses.push(`field_one = $${params.length + 1}`)
+      params.push(input.fieldOne)
+    }
+    if (input.fieldTwo !== undefined) {
+      setClauses.push(`field_two = $${params.length + 1}`)
+      params.push(input.fieldTwo)
+    }
+
+    const row = await this.db.queryOne(
+      `UPDATE <table> SET ${setClauses.join(", ")} WHERE id = $1 AND deleted_at IS NULL
+       RETURNING id, field_one, field_two, created_at, updated_at`,
+      params
+    )
+
+    if (!row) throw new NotFoundError("<Entity>", id)
+    return this.mapRowToEntity(row)
+  }
+
+  async delete(id: string): Promise<void> {
+    // Hard delete — use soft delete variant below if the domain requires it
+    await this.db.execute(
+      "DELETE FROM <table> WHERE id = $1",
+      [id]
+    )
+  }
+
+  // Soft delete variant — use instead of hard delete when audit/recovery is required
+  async softDelete(id: string): Promise<void> {
+    await this.db.execute(
+      "UPDATE <table> SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1 AND deleted_at IS NULL",
+      [id]
+    )
+  }
+
+  async exists(id: string): Promise<boolean> {
+    const row = await this.db.queryOne(
+      "SELECT 1 FROM <table> WHERE id = $1 AND deleted_at IS NULL",
+      [id]
+    )
+    return row !== null
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: row → domain entity mapping
+  // -------------------------------------------------------------------------
+  private mapRowToEntity(row: Record<string, unknown>): <Entity> {
+    return {
+      id: row.id as string,
+      fieldOne: row.field_one as string,
+      fieldTwo: row.field_two as string,
+      createdAt: row.created_at as Date,
+      updatedAt: row.updated_at as Date
+    }
+  }
+}
+```
+
+---
+
+## Checklist
+
+Before shipping a repository implementation:
+
+- [ ] All queries use parameterized placeholders — no string concatenation of user input.
+- [ ] All collection queries have a `LIMIT` clause and return `nextCursor` or equivalent.
+- [ ] The `mapRowToEntity` function maps every column — no implicit `*` leakage.
+- [ ] Soft deletes filter on `deleted_at IS NULL` in every read query.
+- [ ] The repository interface is tested with both a real database (integration) and a mock (unit).
+- [ ] No business logic exists in this file — only query construction and row mapping.

--- a/skills/backend-dev/service-template.md
+++ b/skills/backend-dev/service-template.md
@@ -1,0 +1,167 @@
+# Service Layer Template
+
+Use this template to scaffold a service class or module. Replace all `<placeholder>` values. The pattern is framework-agnostic — adapt the syntax to the language and runtime in use.
+
+---
+
+## Service Contract
+
+Define the public interface for this service before writing the implementation.
+
+```
+Service: <ServiceName>
+Bounded context: <what domain concern this service owns>
+Dependencies: <list external dependencies — repositories, message clients, config>
+```
+
+---
+
+## Pseudocode Scaffold
+
+The following scaffold shows the expected structure. Implement in the project language.
+
+```
+class <ServiceName>Service {
+
+  // Injected dependencies — never construct inside service methods
+  repository: <EntityRepository>
+  logger: Logger
+  // Add other dependencies: messageClient, cacheClient, configService, etc.
+
+  constructor(repository, logger, /* other deps */) {
+    this.repository = repository
+    this.logger = logger
+    // Assign remaining deps
+  }
+
+  // -------------------------------------------------------------------------
+  // Public methods — one method per use case
+  // -------------------------------------------------------------------------
+
+  async create<Entity>(input: Create<Entity>Input): Promise<<Entity>> {
+    // 1. Validate input
+    validate(input)  // throws ValidationError with field details on failure
+
+    // 2. Apply business rules
+    // ... domain logic here
+
+    // 3. Persist via repository
+    const entity = await this.repository.create(input)
+
+    // 4. Log the operation
+    this.logger.info({
+      event: "<entity>.created",
+      entityId: entity.id,
+      correlationId: context.correlationId
+    })
+
+    // 5. Return the created entity
+    return entity
+  }
+
+  async get<Entity>ById(id: string): Promise<<Entity> | null> {
+    const entity = await this.repository.findById(id)
+
+    if (!entity) {
+      this.logger.warn({
+        event: "<entity>.not_found",
+        id,
+        correlationId: context.correlationId
+      })
+      return null  // caller translates null to 404
+    }
+
+    return entity
+  }
+
+  async update<Entity>(id: string, input: Update<Entity>Input): Promise<<Entity>> {
+    // 1. Validate input
+    validate(input)
+
+    // 2. Verify entity exists
+    const existing = await this.repository.findById(id)
+    if (!existing) {
+      throw new NotFoundError("<Entity>", id)
+    }
+
+    // 3. Apply business rules
+    // ... merge changes, enforce invariants
+
+    // 4. Persist
+    const updated = await this.repository.update(id, input)
+
+    this.logger.info({
+      event: "<entity>.updated",
+      entityId: id,
+      correlationId: context.correlationId
+    })
+
+    return updated
+  }
+
+  async delete<Entity>(id: string): Promise<void> {
+    const existing = await this.repository.findById(id)
+    if (!existing) {
+      throw new NotFoundError("<Entity>", id)
+    }
+
+    await this.repository.delete(id)
+
+    this.logger.info({
+      event: "<entity>.deleted",
+      entityId: id,
+      correlationId: context.correlationId
+    })
+  }
+
+  async list<Entity>s(filters: <Entity>Filters): Promise<PaginatedResult<<Entity>>> {
+    // Enforce pagination — never return unbounded results
+    const pageSize = Math.min(filters.pageSize ?? 20, 100)
+
+    return this.repository.list({ ...filters, pageSize })
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers — kept private, each under 40 lines
+  // -------------------------------------------------------------------------
+
+  private validate(input: unknown): asserts input is Valid<Entity>Input {
+    // Enforce types, required fields, length limits, format constraints
+    // Throw ValidationError with field-level details on failure
+  }
+}
+```
+
+---
+
+## Error Types to Define
+
+| Error type | When to throw | HTTP mapping |
+|---|---|---|
+| `ValidationError` | Input fails schema or business rule | `422` |
+| `NotFoundError` | Entity does not exist | `404` |
+| `ConflictError` | Unique constraint or optimistic lock failure | `409` |
+| `UnauthorizedError` | Auth check fails inside domain logic | `403` |
+| `ServiceError` | Unexpected internal failure | `500` |
+
+---
+
+## Logging Checklist
+
+Every service method must log:
+
+- [ ] Operation started (optional, for long-running operations)
+- [ ] Operation succeeded (INFO, include entity ID and correlationId)
+- [ ] Validation failure (WARN, include field details — no PII)
+- [ ] Not found (WARN, include the looked-up ID)
+- [ ] Unexpected error (ERROR, include error message and stack — no secrets)
+
+---
+
+## Testing Expectations
+
+- Unit tests mock all repositories and external clients.
+- One test per positive path (happy path for each public method).
+- One test per named error path (not found, validation failure, conflict, etc.).
+- Verify that the repository was called with the expected arguments.
+- Verify that the logger was called with the expected event names.

--- a/skills/data-tier/SKILL.md
+++ b/skills/data-tier/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: data-tier
+description: "Use when designing schemas, writing migrations, reviewing queries, or establishing data access patterns. Provides schema design, migration, query review, and data dictionary templates."
+---
+
+# Data Tier Skill
+
+Use this skill when the task involves schema design, database migrations, query review, indexing strategy, or data access pattern definition.
+
+## When to Use
+
+- Designing a new schema or extending an existing one
+- Writing a migration with rollback support
+- Reviewing queries for N+1 risk, missing indexes, or unbounded result sets
+- Building a data dictionary for a domain
+- Establishing the repository or data access layer for a service
+
+## How to Invoke
+
+Reference this skill by attaching `skills/data-tier/SKILL.md` to your agent context, or instruct the agent:
+
+> Use the data-tier skill. Apply the schema design template, migration template, and query review checklist to the data work being done.
+
+## Templates in This Skill
+
+| Template | Purpose |
+|---|---|
+| `schema-design-template.md` | Schema design document: entities, attributes, relationships, constraints, and indexes |
+| `migration-template.md` | Migration scaffold with up/down blocks, rollback plan, and zero-downtime notes |
+| `query-review-checklist.md` | Query review checklist: N+1 check, index usage, pagination, explain plan guidance |
+| `data-dictionary-template.md` | Data dictionary: table, column, type, nullable, description, and example values |
+
+## Agent Pairing
+
+This skill is designed to be used alongside the `data-tier` agent. The agent drives the workflow; this skill provides the reference templates and review checklists.
+
+The data tier persists domain entities defined by the `backend-dev` agent. Changes to schema require coordination with the `backend-dev` agent to keep repository patterns aligned.

--- a/skills/data-tier/data-dictionary-template.md
+++ b/skills/data-tier/data-dictionary-template.md
@@ -1,0 +1,97 @@
+# Data Dictionary Template
+
+Use this template to document every table and column in the service's schema. Keep this document in source control alongside migrations. Update it whenever a migration adds, changes, or removes columns.
+
+---
+
+## Data Dictionary Overview
+
+| Field | Value |
+|---|---|
+| **Service / Domain** | `<service name>` |
+| **Database** | `<database name>` |
+| **Schema** | `public` / `<schema name>` |
+| **Last Updated** | `YYYY-MM-DD` |
+| **Migration Baseline** | `<last migration ID applied>` |
+
+---
+
+## Table: `<table_name>`
+
+**Description:** One sentence describing what this table stores and its role in the domain.
+
+**Retention policy:** `<permanent | N days | archived after N months | purged on deletion>`
+
+**Multi-tenant:** Yes — isolated by `tenant_id` column. / No.
+
+**Soft delete:** Yes — `deleted_at IS NULL` filters active records. / No.
+
+### Columns
+
+| Column | Type | Nullable | Default | Description | Example Value |
+|---|---|---|---|---|---|
+| `id` | `UUID` | No | `gen_random_uuid()` | Primary key — surrogate UUID | `"a1b2c3d4-..."` |
+| `tenant_id` | `UUID` | No | — | Foreign key to `tenants.id`. Isolates data per tenant. | `"9f8e7d6c-..."` |
+| `name` | `VARCHAR(255)` | No | — | Human-readable display name. Validated: non-empty, max 255 characters. | `"Acme Corporation"` |
+| `status` | `VARCHAR(50)` | No | `'pending'` | Lifecycle status. Enum: `pending`, `active`, `suspended`, `closed`. | `"active"` |
+| `description` | `TEXT` | Yes | `NULL` | Optional long-form description. Not indexed. | `"A detailed note..."` |
+| `amount` | `DECIMAL(19,4)` | No | `0.0000` | Monetary amount in the account's native currency. Never stored as float. | `1234.5600` |
+| `is_archived` | `BOOLEAN` | No | `false` | Whether this record is archived (read-only). Not the same as soft-delete. | `false` |
+| `metadata` | `JSONB` | Yes | `NULL` | Unstructured key-value extension point. Schema is not enforced at the DB level. | `{"source": "api"}` |
+| `<fk_column>_id` | `UUID` | No | — | Foreign key to `<other_table>.id`. References the owning `<other_entity>`. | `"d4e5f6a7-..."` |
+| `created_at` | `TIMESTAMPTZ` | No | `NOW()` | UTC timestamp of record creation. Set once; never updated. | `"2025-01-15T10:30:00Z"` |
+| `updated_at` | `TIMESTAMPTZ` | No | `NOW()` | UTC timestamp of last modification. Updated on every write. | `"2025-06-01T08:00:00Z"` |
+| `deleted_at` | `TIMESTAMPTZ` | Yes | `NULL` | UTC timestamp of soft deletion. `NULL` = active record. Never hard-deleted. | `"2025-07-01T00:00:00Z"` |
+
+### Indexes
+
+| Index Name | Columns | Type | Purpose |
+|---|---|---|---|
+| `<table>_pkey` | `(id)` | PRIMARY KEY | Unique row lookup |
+| `<table>_tenant_id_idx` | `(tenant_id)` | B-Tree | Required for every multi-tenant table |
+| `<table>_status_tenant_idx` | `(tenant_id, status)` | B-Tree | Composite index for tenant-scoped status filter queries |
+| `<table>_created_at_idx` | `(created_at DESC)` | B-Tree | Sort and feed queries by newest first |
+| `<table>_<fk>_idx` | `(<fk_column>_id)` | B-Tree | Required on every FK column |
+
+### Foreign Keys
+
+| Constraint Name | Column | References | On Delete |
+|---|---|---|---|
+| `<table>_tenant_id_fkey` | `tenant_id` | `tenants(id)` | CASCADE |
+| `<table>_<fk>_fkey` | `<fk_column>_id` | `<other_table>(id)` | RESTRICT |
+
+### Check Constraints
+
+| Constraint Name | Expression | Purpose |
+|---|---|---|
+| `<table>_status_check` | `status IN ('pending', 'active', 'suspended', 'closed')` | Enforce valid enum values |
+| `<table>_amount_non_negative` | `amount >= 0` | Business rule: amounts cannot be negative |
+
+---
+
+## Table: `<next_table_name>`
+
+_Repeat the section above for each table in the schema._
+
+---
+
+## Enum Reference
+
+Document shared enum values used across multiple tables.
+
+| Enum Name | Values | Used In |
+|---|---|---|
+| `status` | `pending`, `active`, `suspended`, `closed` | `<table_a>`, `<table_b>` |
+| `event_type` | `created`, `updated`, `deleted`, `archived` | `<audit_log_table>` |
+
+---
+
+## Change Log
+
+Track significant schema changes in this dictionary. Full migration history is in the migration files.
+
+| Date | Migration ID | Change |
+|---|---|---|
+| `YYYY-MM-DD` | `<migration_id>` | Added `<column>` to `<table>` |
+| `YYYY-MM-DD` | `<migration_id>` | Created `<new_table>` |
+| `YYYY-MM-DD` | `<migration_id>` | Deprecated `<column>` on `<table>` (soft-deleted column, scheduled for removal in v2) |

--- a/skills/data-tier/migration-template.md
+++ b/skills/data-tier/migration-template.md
@@ -1,0 +1,140 @@
+# Migration Template
+
+Use this template for every database migration file. Fill in all sections before writing the SQL. A migration without a `down` block is not complete.
+
+---
+
+## Migration Header
+
+```
+Migration ID:    <YYYYMMDDHHMMSS>_<short_description>
+Description:     <one sentence describing what this migration does>
+Ticket/Issue:    #<issue number>
+Author:          <name or alias>
+Created:         YYYY-MM-DD
+Zero-downtime:   Yes / No (explain why not if No)
+Reversible:      Yes / No (explain why not if No)
+```
+
+---
+
+## Pre-Migration Checklist
+
+Complete before applying this migration in any environment.
+
+- [ ] Migration has been reviewed by at least one other engineer.
+- [ ] The `down` block has been tested in a local or staging environment.
+- [ ] Destructive operations (`DROP COLUMN`, `DROP TABLE`, `TRUNCATE`) have a confirmed backup.
+- [ ] Large table operations have a plan for avoiding lock contention (batching, `CONCURRENTLY`, maintenance window).
+- [ ] Application code is already forward-compatible with the new schema (feature flag, dual-read/write, or deploy ordering confirmed).
+- [ ] This migration does not change an existing column type without a compatibility plan.
+
+---
+
+## Up Migration
+
+```sql
+-- Migration: <YYYYMMDDHHMMSS>_<short_description>
+-- Description: <one sentence>
+-- Reversible: Yes
+
+BEGIN;
+
+-- Step 1: <describe what this step does>
+-- Zero-downtime note: Adding a nullable column first; constraint added in a subsequent migration.
+ALTER TABLE <table_name>
+  ADD COLUMN <column_name> <type> NULL;
+
+-- Step 2: <describe what this step does>
+CREATE INDEX CONCURRENTLY IF NOT EXISTS <index_name>
+  ON <table_name> (<column_name>);
+
+-- Step 3: <describe what this step does>
+-- Example: add a new table
+CREATE TABLE IF NOT EXISTS <new_table_name> (
+  id          UUID          NOT NULL DEFAULT gen_random_uuid(),
+  <fk_column> UUID          NOT NULL,
+  <column>    VARCHAR(255)  NOT NULL,
+  created_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT <new_table_name>_pkey PRIMARY KEY (id),
+  CONSTRAINT <new_table_name>_<fk_column>_fkey
+    FOREIGN KEY (<fk_column>) REFERENCES <referenced_table>(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS <new_table_name>_<fk_column>_idx
+  ON <new_table_name> (<fk_column>);
+
+COMMIT;
+```
+
+---
+
+## Down Migration (Rollback)
+
+```sql
+-- Rollback for: <YYYYMMDDHHMMSS>_<short_description>
+-- Warning: rolling back drops <new_table_name>. Ensure no data has been written before rolling back.
+
+BEGIN;
+
+-- Reverse Step 3
+DROP TABLE IF EXISTS <new_table_name>;
+
+-- Reverse Step 2
+DROP INDEX CONCURRENTLY IF EXISTS <index_name>;
+
+-- Reverse Step 1
+ALTER TABLE <table_name>
+  DROP COLUMN IF EXISTS <column_name>;
+
+COMMIT;
+```
+
+---
+
+## Rollback Plan
+
+Document what happens if this migration needs to be reversed in production.
+
+| Scenario | Action |
+|---|---|
+| Migration fails mid-run | Transaction rolls back automatically (if transactional DDL is supported). Re-apply after fix. |
+| Migration applied but application has a bug | Run the down migration. Redeploy previous application version. |
+| Data was written in the new schema before rollback | Requires manual data migration to reverse. Contact DBA before proceeding. |
+
+---
+
+## Zero-Downtime Notes
+
+| Operation | Zero-Downtime Strategy |
+|---|---|
+| Adding a column | Add as `NULL` first. Backfill with a background job. Add `NOT NULL` constraint in a later migration once all rows are populated. |
+| Adding an index | Use `CREATE INDEX CONCURRENTLY` to avoid locking the table. |
+| Renaming a column | (1) Add new column. (2) Dual-write. (3) Migrate reads to new column. (4) Drop old column in a later release. |
+| Dropping a column | (1) Stop reading/writing in application code (deploy first). (2) Drop column in this migration. |
+| Changing a column type | Never alter type in place. Add a new column with the new type, migrate data, then drop the old column. |
+
+---
+
+## Post-Migration Validation Queries
+
+Run these queries after applying the migration to confirm the expected state.
+
+```sql
+-- Verify new column exists
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = '<table_name>'
+  AND column_name = '<column_name>';
+
+-- Verify new index exists
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = '<table_name>'
+  AND indexname = '<index_name>';
+
+-- Verify new table exists and row count is as expected
+SELECT COUNT(*) FROM <new_table_name>;
+```

--- a/skills/data-tier/query-review-checklist.md
+++ b/skills/data-tier/query-review-checklist.md
@@ -1,0 +1,117 @@
+# Query Review Checklist
+
+Use this checklist when writing or reviewing database queries. Every item must be verified before a query ships to production. Mark each: ✅ Pass, ❌ Fail (file a GitHub Issue), or N/A.
+
+---
+
+## 1. Correctness
+
+- [ ] The query returns the expected rows for the target use case.
+- [ ] Filters on `deleted_at IS NULL` are applied on every query against a soft-delete table.
+- [ ] Multi-tenant queries filter on `tenant_id` in the `WHERE` clause — no cross-tenant data leakage.
+- [ ] JOINs use the correct join type (`INNER`, `LEFT`, `RIGHT`) for the intended null-handling semantics.
+- [ ] Aggregations (`GROUP BY`) include all non-aggregated columns in the `SELECT` clause.
+- [ ] Date/time comparisons account for timezone (use UTC consistently).
+
+---
+
+## 2. N+1 Detection
+
+- [ ] No query is executed inside a loop or per-row callback.
+- [ ] Related entities are fetched with JOINs, batch queries (`WHERE id IN (...)`) or eager loading — not one query per parent row.
+- [ ] If an ORM is in use, generated SQL has been inspected for unintended per-row queries (use query logging in development/test).
+- [ ] Nested relationship traversal depth has been assessed. More than two levels of lazy loading is a red flag.
+
+**Rule of thumb:** The number of database queries executed for a request should be fixed (O(1)) relative to the size of the result set, not proportional to it.
+
+---
+
+## 3. Pagination
+
+- [ ] Every collection query has a `LIMIT` clause with a server-enforced maximum.
+- [ ] The query cannot be called without pagination parameters (no unbounded `SELECT * FROM table`).
+- [ ] Cursor-based pagination is used for large or frequently changing datasets.
+- [ ] Offset-based pagination documents the known limitation (instability under concurrent inserts/deletes).
+- [ ] The response includes `nextCursor` (or `hasMore` / `totalCount`) so callers can detect end-of-results.
+
+---
+
+## 4. Index Usage
+
+- [ ] Run `EXPLAIN ANALYZE` (or equivalent) on the query and review the output.
+- [ ] The query plan shows index scans, not sequential scans, for filtered columns on tables with more than ~1,000 rows.
+- [ ] Composite index column order matches the query's filter and sort columns (leftmost prefix rule applies).
+- [ ] Columns used in `WHERE`, `JOIN ON`, and `ORDER BY` have indexes unless the table is known to be small and stable.
+- [ ] Every foreign key column has an index.
+- [ ] The query does not use a function on an indexed column in the `WHERE` clause (e.g., `LOWER(email) = ...` — use a functional index instead).
+
+---
+
+## 5. Select Columns
+
+- [ ] `SELECT *` is not used in production code paths. List only the columns the query actually needs.
+- [ ] The selected columns match what the application layer actually uses — no unused columns fetched.
+- [ ] Blob or large text columns (`TEXT`, `BYTEA`, `CLOB`) are excluded from list queries and fetched only in detail queries.
+
+---
+
+## 6. Query Safety
+
+- [ ] All user-supplied values are passed as parameterized placeholders — no string concatenation.
+- [ ] Dynamic column or table names (if unavoidable) are validated against an allowlist before use.
+- [ ] Bulk `IN` clauses have a documented maximum size to prevent excessive query plan cost.
+
+---
+
+## 7. Bulk Operations
+
+- [ ] Batch inserts use multi-row `INSERT` syntax, not one `INSERT` per row.
+- [ ] Bulk updates and deletes apply a `WHERE` clause that limits the number of affected rows per batch.
+- [ ] Long-running bulk operations are chunked to avoid locking the table for the duration.
+- [ ] Bulk operations are wrapped in a transaction when atomicity is required.
+
+---
+
+## 8. Explain Plan Interpretation
+
+Run `EXPLAIN ANALYZE` (PostgreSQL) or `EXPLAIN FORMAT=JSON` (MySQL) and check for:
+
+| Signal | What it means | Action |
+|---|---|---|
+| `Seq Scan` on large table | No index used — full table scan | Add index on filter column |
+| `Nested Loop` with high estimated rows | Possible N+1 inside the query | Restructure with JOIN or batch |
+| `Sort` without index | Sort is done in memory or on disk | Add index on the ORDER BY column |
+| High `actual rows` vs `estimated rows` | Stale statistics | Run `ANALYZE <table>` |
+| `Hash Join` on very large tables | High memory use | Consider tuning `work_mem` or adding index |
+| `rows=1` but actual rows > 1000 | Bad cardinality estimate | Check for data distribution skew; update statistics |
+
+---
+
+## Filing a Query Review Issue
+
+When any item above fails, file a GitHub Issue:
+
+```bash
+gh issue create \
+  --title "[Tech Debt] <short description>" \
+  --label "tech-debt,data,performance" \
+  --body "## Query Review Finding
+
+**Category:** <N+1 | missing index | SELECT * | unbounded query | unsafe parameterization>
+**File:** <path/to/file.ext>
+**Query / Line(s):** <line range or query snippet>
+
+### What Failed
+<description of the specific problem>
+
+### Impact
+<performance risk, correctness risk, or security risk>
+
+### Recommended Fix
+<concise recommendation>
+
+### Acceptance Criteria
+- [ ] EXPLAIN ANALYZE shows index scan (not seq scan) after fix
+- [ ] Query has LIMIT clause
+- [ ] No N+1 queries on this path"
+```

--- a/skills/data-tier/schema-design-template.md
+++ b/skills/data-tier/schema-design-template.md
@@ -1,0 +1,120 @@
+# Schema Design Template
+
+Use this template to document a database schema before implementation. Complete all sections. A schema document prevents ambiguous migrations and missing constraints.
+
+---
+
+## Schema Overview
+
+| Field | Value |
+|---|---|
+| **Domain / Service** | `<service or bounded context name>` |
+| **Database type** | PostgreSQL / MySQL / SQL Server / SQLite / Other |
+| **Multi-tenant** | Yes (tenant isolation via `tenant_id` column) / No |
+| **Soft delete** | Yes (`deleted_at` column) / No |
+| **Author** | `<name or team>` |
+| **Last Updated** | `YYYY-MM-DD` |
+
+---
+
+## Entities
+
+List every table or entity. For each entity, describe its purpose in one sentence.
+
+| Entity (Table Name) | Purpose |
+|---|---|
+| `<table_name>` | <one-sentence description> |
+| `<table_name>` | <one-sentence description> |
+
+---
+
+## Entity Detail: `<table_name>`
+
+Repeat this section for every entity.
+
+### Columns
+
+| Column | Type | Nullable | Default | Description |
+|---|---|---|---|---|
+| `id` | `UUID` / `BIGINT` | No | `gen_random_uuid()` / auto-increment | Primary key |
+| `tenant_id` | `UUID` | No | — | Multi-tenant isolation key |
+| `<column_name>` | `VARCHAR(255)` | No | — | Description of this column |
+| `<column_name>` | `DECIMAL(19,4)` | No | `0.00` | Monetary amount in native currency |
+| `<column_name>` | `BOOLEAN` | No | `false` | Whether the record is active |
+| `<column_name>` | `TEXT` | Yes | `NULL` | Optional long-form content |
+| `status` | `VARCHAR(50)` | No | `'pending'` | Enum: `pending`, `active`, `closed` |
+| `created_at` | `TIMESTAMPTZ` | No | `NOW()` | Record creation time, UTC |
+| `updated_at` | `TIMESTAMPTZ` | No | `NOW()` | Last modification time, UTC |
+| `deleted_at` | `TIMESTAMPTZ` | Yes | `NULL` | Soft delete timestamp; NULL = not deleted |
+
+### Constraints
+
+| Constraint | Type | Definition |
+|---|---|---|
+| `<table>_pkey` | PRIMARY KEY | `(id)` |
+| `<table>_tenant_id_fkey` | FOREIGN KEY | `(tenant_id) REFERENCES tenants(id) ON DELETE CASCADE` |
+| `<table>_<column>_fkey` | FOREIGN KEY | `(<column>) REFERENCES <other_table>(id) ON DELETE RESTRICT` |
+| `<table>_status_check` | CHECK | `status IN ('pending', 'active', 'closed')` |
+| `<table>_<column>_not_negative` | CHECK | `<column> >= 0` |
+| `<table>_<columns>_unique` | UNIQUE | `(tenant_id, <natural_key_column>)` |
+
+### Indexes
+
+| Index Name | Columns | Type | Rationale |
+|---|---|---|---|
+| `<table>_tenant_id_idx` | `(tenant_id)` | B-Tree | All queries filter by tenant |
+| `<table>_<fk>_idx` | `(<fk_column>)` | B-Tree | Every FK column gets an index |
+| `<table>_created_at_idx` | `(created_at DESC)` | B-Tree | Feed queries sorted by newest first |
+| `<table>_status_tenant_idx` | `(tenant_id, status)` | B-Tree | Composite for multi-tenant status filter queries |
+
+### Notes
+
+Document any non-obvious design decisions for this table.
+
+- Why this normalization level was chosen
+- Any planned denormalization and its justification
+- Soft delete policy and filter expectations
+- Audit or compliance requirements affecting this table
+
+---
+
+## Relationships
+
+Describe relationships between entities.
+
+| Relationship | Type | Notes |
+|---|---|---|
+| `<table_a>` → `<table_b>` | One-to-many | Each `<table_a>` record has many `<table_b>` records |
+| `<table_b>` → `<table_c>` | Many-to-one | Each `<table_b>` belongs to one `<table_c>` |
+| `<table_a>` ↔ `<table_c>` | Many-to-many | Via join table `<table_a_table_c>` |
+
+---
+
+## Entity Relationship Diagram (ERD)
+
+Sketch the relationships in ASCII or Mermaid syntax.
+
+```mermaid
+erDiagram
+  TABLE_A {
+    uuid id PK
+    uuid tenant_id FK
+    varchar status
+    timestamptz created_at
+  }
+  TABLE_B {
+    uuid id PK
+    uuid table_a_id FK
+    varchar name
+  }
+  TABLE_A ||--o{ TABLE_B : "has many"
+```
+
+---
+
+## Open Questions
+
+List schema decisions that need stakeholder input before the migration is written.
+
+1. `<open question>`
+2. `<open question>`

--- a/skills/frontend-dev/SKILL.md
+++ b/skills/frontend-dev/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: frontend-dev
+description: "Use when building UI components, implementing responsive layouts, auditing accessibility, or designing state management. Provides component spec, accessibility checklist, and state management templates."
+---
+
+# Frontend Development Skill
+
+Use this skill when the task involves building UI components, implementing responsive designs, auditing accessibility compliance, or structuring client-side state.
+
+## When to Use
+
+- Scaffolding a new UI component with props, states, and accessibility requirements
+- Auditing a component or page against WCAG 2.1 AA
+- Designing a state management structure for a feature
+- Reviewing a frontend implementation for accessibility, performance, or correctness
+
+## How to Invoke
+
+Reference this skill by attaching `skills/frontend-dev/SKILL.md` to your agent context, or instruct the agent:
+
+> Use the frontend-dev skill. Apply the component spec template and accessibility checklist to every component being built or reviewed.
+
+## Templates in This Skill
+
+| Template | Purpose |
+|---|---|
+| `component-spec-template.md` | Component specification: props, events, children, accessibility requirements, and all UI states |
+| `accessibility-checklist.md` | WCAG 2.1 AA checklist organized by perceivable, operable, understandable, and robust principles |
+| `state-management-template.md` | State structure template covering local state, shared state, async state, and error/loading patterns |
+
+## Agent Pairing
+
+This skill is designed to be used alongside the `frontend-dev` agent. The agent drives the workflow; this skill provides the reference templates and audit checklists.
+
+Frontend components consume API contracts defined by the `backend-dev` agent. Route data schema questions to the `data-tier` agent.

--- a/skills/frontend-dev/accessibility-checklist.md
+++ b/skills/frontend-dev/accessibility-checklist.md
@@ -1,0 +1,150 @@
+# Accessibility Checklist — WCAG 2.1 AA
+
+Use this checklist when building, reviewing, or auditing a UI component or page. Every item must pass before the feature ships. Mark each item: ✅ Pass, ❌ Fail (file a GitHub Issue), or N/A.
+
+---
+
+## 1. Perceivable
+
+Information and UI components must be presentable to users in ways they can perceive.
+
+### 1.1 Text Alternatives
+
+- [ ] All non-text content (images, icons, charts) has a text alternative via `alt`, `aria-label`, or `aria-labelledby`.
+- [ ] Decorative images use `alt=""` so screen readers skip them.
+- [ ] Icons used as interactive controls have accessible names (not just a visual icon).
+- [ ] Complex images (charts, diagrams) have a long description available (`longdesc`, adjacent prose, or `aria-describedby`).
+
+### 1.2 Time-Based Media
+
+- [ ] Prerecorded audio-only content has a text transcript.
+- [ ] Prerecorded video-only content has a text or audio alternative.
+- [ ] Prerecorded video with audio has synchronized captions.
+- [ ] If audio plays automatically for more than 3 seconds, there is a mechanism to pause or stop it.
+
+### 1.3 Adaptable
+
+- [ ] Information and relationships conveyed through presentation are also programmatically determinable (not conveyed only through color or visual layout).
+- [ ] Sequence of content in the DOM matches the visual reading order.
+- [ ] Instructions do not rely solely on sensory characteristics (shape, color, position, sound) to identify content.
+- [ ] Content does not restrict orientation (portrait/landscape) unless essential.
+
+### 1.4 Distinguishable
+
+- [ ] Color is not used as the sole visual means of conveying information, indicating an action, or distinguishing a visual element.
+- [ ] Body text color contrast ratio is at least **4.5:1** against its background.
+- [ ] Large text (18pt / 14pt bold or larger) color contrast ratio is at least **3:1**.
+- [ ] UI components (inputs, buttons, focus indicators) have a contrast ratio of at least **3:1** against adjacent colors.
+- [ ] Text can be resized to 200% without loss of content or functionality.
+- [ ] No information is lost when text spacing is adjusted (line height 1.5×, letter spacing 0.12em, word spacing 0.16em, paragraph spacing 2em).
+- [ ] Content does not require horizontal scrolling at 320px width (400% zoom equivalent).
+- [ ] Background audio is at least 20 dB quieter than foreground speech, or can be turned off.
+
+---
+
+## 2. Operable
+
+UI components and navigation must be operable.
+
+### 2.1 Keyboard Accessible
+
+- [ ] All functionality is operable via keyboard without requiring specific timing.
+- [ ] No keyboard traps — focus can always move away from a component using standard keys.
+- [ ] If a keyboard shortcut uses a single character, it can be turned off or remapped.
+
+### 2.2 Enough Time
+
+- [ ] If there is a time limit, users can turn it off, adjust it, or extend it (unless it is essential).
+- [ ] Moving, blinking, or scrolling content that starts automatically and lasts more than 5 seconds can be paused, stopped, or hidden.
+- [ ] Auto-updating content can be paused, stopped, or controlled by the user.
+
+### 2.3 Seizures and Physical Reactions
+
+- [ ] No content flashes more than three times per second.
+- [ ] No general flash threshold or red flash threshold is exceeded.
+
+### 2.4 Navigable
+
+- [ ] Skip navigation links are provided so keyboard users can bypass repeated navigation blocks.
+- [ ] Pages have a descriptive `<title>` element.
+- [ ] Focus order follows a logical, meaningful sequence.
+- [ ] The purpose of each link is clear from the link text alone, or from context.
+- [ ] Multiple ways to find a page exist (search, site map, navigation).
+- [ ] Headings and labels are descriptive.
+- [ ] Keyboard focus is always visible — never set `outline: none` without a replacement focus style.
+
+### 2.5 Input Modalities
+
+- [ ] All functionality that uses a path-based gesture (drag, swipe) can also be operated with a single pointer.
+- [ ] Pointer-activated functions can be cancelled (e.g., the up-event, not the down-event, triggers the action).
+- [ ] Controls activated by motion (shaking, tilting) can also be activated through UI and can be disabled.
+- [ ] Target size for pointer inputs is at least **24×24 CSS pixels**.
+
+---
+
+## 3. Understandable
+
+Information and the operation of the UI must be understandable.
+
+### 3.1 Readable
+
+- [ ] `<html lang="...">` is set to the correct language of the page.
+- [ ] Any passage in a different language is marked with `lang` on the element.
+
+### 3.2 Predictable
+
+- [ ] Changing focus does not automatically trigger a context change (e.g., navigating away from the page).
+- [ ] Changing an input's value does not automatically submit the form or navigate.
+- [ ] Navigation is consistent across pages of the same site.
+- [ ] Components with the same function are identified consistently.
+
+### 3.3 Input Assistance
+
+- [ ] Input errors are identified automatically and described to the user in text.
+- [ ] Labels or instructions are provided for inputs that require a specific format.
+- [ ] Error messages suggest how to correct the input.
+- [ ] For important actions (submit, delete, purchase), a review step, undo mechanism, or confirmation is provided.
+
+---
+
+## 4. Robust
+
+Content must be robust enough that it can be interpreted by a wide variety of user agents, including assistive technologies.
+
+### 4.1 Compatible
+
+- [ ] HTML is valid — no duplicate IDs, no unclosed tags, no missing required attributes.
+- [ ] All UI components have accessible names, roles, and values that are programmatically determinable.
+- [ ] ARIA roles, states, and properties are used correctly according to the ARIA specification.
+- [ ] Status messages (e.g., "3 items added to cart") are announced to assistive technologies via `role="status"` or `aria-live` without requiring focus.
+
+---
+
+## Filing an Accessibility Issue
+
+When any item above fails, file a GitHub Issue immediately:
+
+```bash
+gh issue create \
+  --title "[Accessibility] <short description>" \
+  --label "tech-debt,frontend,accessibility" \
+  --body "## Accessibility Failure
+
+**WCAG Criterion:** <e.g., 1.4.3 Contrast (Minimum)>
+**Level:** AA
+**Component / Page:** <path or name>
+**Line(s):** <optional>
+
+### What Failed
+<description of the specific failure>
+
+### Impact
+<who is affected and how — e.g., keyboard users cannot activate the submit button>
+
+### Recommended Fix
+<concise fix recommendation>
+
+### Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>"
+```

--- a/skills/frontend-dev/component-spec-template.md
+++ b/skills/frontend-dev/component-spec-template.md
@@ -1,0 +1,117 @@
+# Component Specification Template
+
+Use this template to define a component before implementation begins. Fill in all sections. A complete spec prevents ambiguous implementations and missing states.
+
+---
+
+## Component Overview
+
+| Field | Value |
+|---|---|
+| **Component Name** | `<ComponentName>` |
+| **Type** | Presentational / Container / Hybrid |
+| **Owner** | `<team or developer>` |
+| **Last Updated** | `YYYY-MM-DD` |
+
+**Description:**
+One sentence describing what this component does and where it is used.
+
+---
+
+## Props / Inputs
+
+| Prop | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<propName>` | `string` | Yes | — | Description of this prop's purpose |
+| `<propName>` | `number` | No | `0` | Description |
+| `<propName>` | `boolean` | No | `false` | Description |
+| `onAction` | `(payload: ActionPayload) => void` | No | — | Callback fired when the primary action occurs |
+| `children` | `ReactNode / slot` | No | — | Slot for composable content |
+
+---
+
+## Events / Callbacks
+
+| Event | Payload | When Emitted |
+|---|---|---|
+| `onChange` | `{ value: string }` | When the user changes the input value |
+| `onSubmit` | `{ data: FormData }` | When the form is submitted successfully |
+| `onError` | `{ code: string, message: string }` | When an error occurs during async operations |
+
+---
+
+## UI States
+
+The component must implement all applicable states below. Mark each as Required or N/A.
+
+| State | Required / N/A | Design Note |
+|---|---|---|
+| **Loading** | Required | Show a skeleton or spinner. Disable interactive elements. |
+| **Error** | Required | Display an inline error message near the affected content. Include a retry affordance if applicable. |
+| **Empty** | Required | Render a meaningful empty state — not a blank region. |
+| **Populated** | Required | Normal content rendering. |
+| **Disabled** | N/A | Visual and interactive disabled state. |
+| **Read-only** | N/A | Content visible but not editable. |
+| **Selected / Active** | N/A | Visual indicator for selected state. |
+
+---
+
+## Accessibility Requirements
+
+Every requirement below must be satisfied before the component ships.
+
+| Requirement | Verification Method |
+|---|---|
+| All interactive elements are keyboard-reachable via `Tab` | Manual keyboard walkthrough |
+| Focus indicator is visible on all focusable elements | Visual inspection |
+| Component has a descriptive `aria-label` or visible label | Inspect DOM |
+| Error messages are announced by screen readers (`role="alert"` or `aria-live`) | Screen reader test |
+| Color is not the sole means of conveying information | Visual inspection |
+| Text contrast ratio meets 4.5:1 (body) or 3:1 (large text) | Automated scan (axe, Lighthouse) |
+| All images have `alt` text or `alt=""` if decorative | Inspect DOM |
+| Semantic HTML used for structure (`button`, `nav`, `main`, etc.) | Inspect DOM |
+
+---
+
+## Children / Slots / Composition
+
+Describe how this component accepts and renders content from its parent.
+
+| Slot | Required | Description |
+|---|---|---|
+| `default` / `children` | No | Primary composed content |
+| `header` | No | Content rendered in the component header area |
+| `footer` | No | Content rendered in the component footer area |
+| `actions` | No | Action buttons or controls rendered in a dedicated area |
+
+---
+
+## Responsive Behavior
+
+| Breakpoint | Behavior |
+|---|---|
+| `< 640px` (mobile) | Describe layout at smallest viewport |
+| `640px – 1023px` (tablet) | Describe layout at medium viewport |
+| `≥ 1024px` (desktop) | Describe layout at full width |
+
+---
+
+## Test Plan
+
+| Scenario | Type | Assertion |
+|---|---|---|
+| Renders in populated state with valid props | Unit | Component output matches snapshot or expected DOM |
+| Renders loading skeleton when `isLoading` is true | Unit | Skeleton is visible, content is not |
+| Renders error message when `error` is set | Unit | Error message text is present and `role="alert"` is applied |
+| Renders empty state when `data` is empty array | Unit | Empty state message is visible |
+| Keyboard user can reach and activate the primary action | Accessibility | Tab to element, Enter/Space activates callback |
+| Screen reader announces error messages | Accessibility | `aria-live` or `role="alert"` present on error region |
+
+---
+
+## Open Questions
+
+List any design or behavior decisions that need clarification before implementation.
+
+1. `<open question>`
+2. `<open question>`

--- a/skills/frontend-dev/state-management-template.md
+++ b/skills/frontend-dev/state-management-template.md
@@ -1,0 +1,140 @@
+# State Management Template
+
+Use this template to design the state structure for a feature or component before writing state logic. Define all state slices, transitions, and async lifecycles before implementation.
+
+---
+
+## Feature / Component State Overview
+
+| Field | Value |
+|---|---|
+| **Feature / Component** | `<FeatureName>` |
+| **State scope** | Local component / Shared context / Global store |
+| **Async operations** | Yes / No |
+| **Last Updated** | `YYYY-MM-DD` |
+
+---
+
+## 1. Local Component State
+
+State that belongs to a single component and does not need to be shared.
+
+| State key | Type | Initial value | Description |
+|---|---|---|---|
+| `isOpen` | `boolean` | `false` | Controls whether a modal or panel is visible |
+| `inputValue` | `string` | `""` | Controlled input value before submission |
+| `selectedId` | `string \| null` | `null` | Currently selected item ID |
+
+**Guideline:** If state is referenced by more than one component, it is not local — promote it to shared state.
+
+---
+
+## 2. Shared State (Context / Store)
+
+State shared by multiple components. Document the shape and the scope (which components have access).
+
+```
+State slice: <sliceName>
+
+{
+  "<entityName>": {
+    data: <Entity>[] | null,  // null means not yet loaded
+    status: "idle" | "loading" | "success" | "error",
+    error: { code: string, message: string } | null,
+    pagination: {
+      pageSize: number,
+      nextCursor: string | null,
+      total: number | null
+    }
+  },
+  "selectedId": string | null,
+  "filters": {
+    searchQuery: string,
+    sortBy: "createdAt" | "name",
+    sortOrder: "asc" | "desc"
+  }
+}
+```
+
+**Access scope:** List the components that read or write this slice.
+
+| Component | Reads | Writes |
+|---|---|---|
+| `<ComponentA>` | `data`, `status` | `filters` |
+| `<ComponentB>` | `selectedId` | `selectedId` |
+
+---
+
+## 3. Async State Lifecycle
+
+Every async operation must model all four phases explicitly.
+
+| Phase | `status` value | UI behavior |
+|---|---|---|
+| Not started | `"idle"` | Show default/empty UI. Enable triggering controls. |
+| In progress | `"loading"` | Show skeleton or spinner. Disable triggering controls to prevent double-submit. |
+| Succeeded | `"success"` | Render data. Clear error state. |
+| Failed | `"error"` | Show error message. Offer retry. Log the error. |
+
+**Transitions:**
+
+```
+idle → loading  (when action is dispatched / fetch begins)
+loading → success  (when data is received)
+loading → error  (when request fails)
+error → loading  (when user retries)
+success → loading  (when user triggers a refresh or next page)
+```
+
+---
+
+## 4. Error State
+
+Define the shape of error state and how it is displayed.
+
+```
+error: {
+  code: string,       // machine-readable error code from the API error catalog
+  message: string,    // human-readable message, safe to display
+  field: string | null  // null for non-field errors; field name for form validation errors
+} | null
+```
+
+**Error display rules:**
+- Non-field errors: render in an inline error banner above the form or content area.
+- Field errors: render adjacent to the input field. Associate via `aria-describedby`.
+- All error messages must use `role="alert"` or be placed in an `aria-live="polite"` region.
+- Never display raw error codes or stack traces to the user.
+
+---
+
+## 5. Derived State
+
+Computed values derived from source state. Do not store derived data in state — compute at render time.
+
+| Derived value | Formula | Used by |
+|---|---|---|
+| `hasResults` | `data !== null && data.length > 0` | `<ComponentA>` — controls empty state rendering |
+| `isFirstPage` | `pagination.nextCursor === null && data?.length === pageSize` | `<ComponentA>` — disables previous button |
+| `canSubmit` | `inputValue.trim().length > 0 && status !== "loading"` | `<FormComponent>` — controls submit button disabled state |
+
+---
+
+## 6. State Initialization
+
+| When | Action |
+|---|---|
+| Component mounts | Set `status` to `"idle"`, clear `error`, clear `data` if stale |
+| User navigates back to the view | Restore from cache if TTL has not expired; otherwise reset to `"idle"` and re-fetch |
+| User logs out | Clear all user-scoped state slices |
+
+---
+
+## 7. Anti-Patterns to Avoid
+
+- ❌ Storing derived values in state (they go stale and diverge from source of truth).
+- ❌ Using `null` and `undefined` interchangeably — pick one semantic per key and stick to it.
+- ❌ Nesting state mutations (treat state updates as immutable replacements).
+- ❌ Setting `status = "success"` before all data for the view has loaded.
+- ❌ Ignoring the `"idle"` phase — components that can be in idle must render an appropriate initial state.
+- ❌ Prop drilling state through more than two component levels — use context or lift higher.

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "name": "base-coat",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "releaseDate": "2026-03-19",
-    "notes": "Added manual test strategy agents, skill, and templates. Updated testing instructions with Manual Test Strategy section."
+    "notes": "Sprint 1: Added backend-dev, frontend-dev, middleware-dev, and data-tier agents with matching skills and development.instructions.md."
 }


### PR DESCRIPTION
## Sprint 1 — Dev Core Agents

Adds the four dev core agents, matching skills, and shared development instruction as part of the enterprise expansion roadmap.

### New Agents

| Agent | Role |
|---|---|
| gents/backend-dev.agent.md | REST/GraphQL APIs, service layers, data access — auto-files issues with \	ech-debt,backend\ |
| gents/frontend-dev.agent.md | Accessible component-driven UIs, WCAG 2.1 AA, Core Web Vitals — auto-files issues with \	ech-debt,frontend,accessibility\ |
| gents/middleware-dev.agent.md | Integration layers, message contracts, circuit breaker/retry/DLQ — auto-files issues with \	ech-debt,middleware,reliability\ |
| gents/data-tier.agent.md | Schema design, reversible migrations, query optimization — auto-files issues with \	ech-debt,data,performance\ |

### New Skills

- \skills/backend-dev/\: SKILL.md, api-spec-template, service-template, error-catalog-template, repository-pattern-template
- \skills/frontend-dev/\: SKILL.md, component-spec-template, accessibility-checklist, state-management-template
- \skills/data-tier/\: SKILL.md, schema-design-template, migration-template, query-review-checklist, data-dictionary-template

### New Instruction

- \instructions/development.instructions.md\: shared standards for all four dev core agents — code style, error handling, security, logging, testing, issue filing, and agent collaboration handoff order

### Metadata

- \ersion.json\ bumped to \