### PR TITLE
feat: add governance stubs to all agents (closes #43-stubs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ It provides four customization types:
 
 The files in this repository are authored as actual customization assets, with descriptive frontmatter so teams can copy them directly into their repos and refine them instead of rewriting from scratch.
 
+## Governance
+
+Base Coat operates under a lightweight enterprise governance framework that applies to all contributions and all agent definitions in this repository.
+
+Key rules:
+
+- **Issue-first**: All changes must be backed by a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a pull request; self-approval is permitted.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+
+Full reference: [`docs/GOVERNANCE.md`](docs/GOVERNANCE.md) · Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+
+> ℹ️ `docs/GOVERNANCE.md` and `CONTRIBUTING.md` are introduced in the companion PR `feature/43-governance-docs` and will be available once that PR merges.
+
 ## Repository Layout
 
 ```text

--- a/agents/code-review.agent.md
+++ b/agents/code-review.agent.md
@@ -25,3 +25,13 @@ Purpose: perform a structured repository or pull request review with emphasis on
 - Findings
 - Open questions
 - Short summary
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Do not make code changes without a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a PR, self-approve if needed.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+- See `instructions/governance.instructions.md` for the full governance reference.

--- a/agents/exploratory-charter.agent.md
+++ b/agents/exploratory-charter.agent.md
@@ -68,3 +68,13 @@ For each session, produce a charter following `skills/manual-test-strategy/chart
 - **Exit criteria**: what ends the session successfully
 
 After the session, produce a brief findings summary with filed GitHub Issues for automation candidates.
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Do not make code changes without a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a PR, self-approve if needed.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+- See `instructions/governance.instructions.md` for the full governance reference.

--- a/agents/manual-test-strategy.agent.md
+++ b/agents/manual-test-strategy.agent.md
@@ -59,3 +59,13 @@ If a sprint label is applicable, append `--label "<sprint-label>"`.
 - Defect evidence template ready for immediate use
 - Automation backlog list with priorities and filed GitHub Issues
 - PR summary including assumptions, coverage boundaries, and next actions
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Do not make code changes without a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a PR, self-approve if needed.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+- See `instructions/governance.instructions.md` for the full governance reference.

--- a/agents/new-customization.agent.md
+++ b/agents/new-customization.agent.md
@@ -26,3 +26,13 @@ Purpose: turn a broad customization request into the right asset with the right 
 - Files created or updated
 - Validation notes
 - Suggested follow-up assets
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Do not make code changes without a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a PR, self-approve if needed.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+- See `instructions/governance.instructions.md` for the full governance reference.

--- a/agents/rollout-basecoat.agent.md
+++ b/agents/rollout-basecoat.agent.md
@@ -27,3 +27,13 @@ Purpose: onboard a repository or portfolio to Base Coat using safe, repeatable r
 - Installed or planned version
 - Validation steps
 - Upgrade guidance
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Do not make code changes without a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a PR, self-approve if needed.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+- See `instructions/governance.instructions.md` for the full governance reference.

--- a/agents/strategy-to-automation.agent.md
+++ b/agents/strategy-to-automation.agent.md
@@ -88,3 +88,13 @@ Produce a summary table at the end:
 - Do not write implementation code for any specific test framework.
 - Do not assume a particular runner, language, or CI toolchain.
 - Do not defer issue filing — every candidate gets an issue before the session ends.
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Do not make code changes without a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a PR, self-approve if needed.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+- See `instructions/governance.instructions.md` for the full governance reference.


### PR DESCRIPTION
## Summary

Adds a `## Governance` section to all 6 agent definition files and updates `README.md` with a governance summary, as part of Issue #43 — Enterprise Governance Framework (Sprint 5 / v1.0.0).

## Changes

### Agent files updated (6)
- `agents/code-review.agent.md`
- `agents/exploratory-charter.agent.md`
- `agents/manual-test-strategy.agent.md`
- `agents/new-customization.agent.md`
- `agents/rollout-basecoat.agent.md`
- `agents/strategy-to-automation.agent.md`

Each agent now includes:
```
## Governance
This agent operates under the basecoat governance framework.
- Issue-first, PRs only, No secrets, Branch naming rules
- See instructions/governance.instructions.md for the full governance reference.
```

### README.md
- Added a top-level `## Governance` section summarising the four key rules
- Links to `docs/GOVERNANCE.md` and `CONTRIBUTING.md`

## Dependencies

> ⚠️ **This PR must merge AFTER `feature/43-governance-docs`.**

`instructions/governance.instructions.md`, `docs/GOVERNANCE.md`, and `CONTRIBUTING.md` are authored in the companion PR `feature/43-governance-docs` (architect's work). The stub references in this PR point to those files. Merging this PR before that one will result in broken links until the dependency lands.

## Related

Closes #43 (governance stubs portion)