### PR TITLE
feat(#61): add CHANGELOG/version.json consistency workflow

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,61 @@
+name: Version Consistency Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate version.json matches latest CHANGELOG entry
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          version_file = Path('version.json')
+          changelog_file = Path('CHANGELOG.md')
+
+          if not version_file.exists():
+              print('::error::version.json not found at repository root')
+              sys.exit(1)
+
+          if not changelog_file.exists():
+              print('::error::CHANGELOG.md not found at repository root')
+              sys.exit(1)
+
+          try:
+              version_data = json.loads(version_file.read_text(encoding='utf-8'))
+          except Exception as exc:
+              print(f'::error::Failed to parse version.json: {exc}')
+              sys.exit(1)
+
+          version = str(version_data.get('version', '')).strip()
+          if not version:
+              print('::error::version.json is missing a non-empty "version" field')
+              sys.exit(1)
+
+          changelog_text = changelog_file.read_text(encoding='utf-8')
+          match = re.search(r'^##\s+v?(\d+\.\d+\.\d+)\b', changelog_text, flags=re.MULTILINE)
+
+          if not match:
+              print('::error::Unable to find latest version heading in CHANGELOG.md (expected format: "## X.Y.Z - YYYY-MM-DD")')
+              sys.exit(1)
+
+          changelog_version = match.group(1)
+
+          if version != changelog_version:
+              print(f'::error::version.json ({version}) does not match latest CHANGELOG.md entry ({changelog_version}). Please keep them in sync.')
+              sys.exit(1)
+
+          print(f'Version consistency check passed: {version}')
+          PY


### PR DESCRIPTION
## Summary
Adds a new CI workflow that verifies `version.json` and the latest `CHANGELOG.md` entry stay in sync.

## What changed
- Added `.github/workflows/version-check.yml`
- Runs on:
  - push to `main`
  - all pull requests
- Validates:
  - `version.json` exists and has a non-empty `version` field
  - `CHANGELOG.md` exists and has a latest heading in `## X.Y.Z` format
  - `version.json.version` exactly matches the latest changelog version
- Fails with clear error output when drift is detected

## Test evidence
Local validation using workflow-equivalent logic:

```bash
python -c "import json,re,sys;from pathlib import Path;vf=Path('version.json');cf=Path('CHANGELOG.md');vd=json.loads(vf.read_text(encoding='utf-8'));v=str(vd.get('version','')).strip();t=cf.read_text(encoding='utf-8');m=re.search(r'^##\\s+v?(\\d+\\.\\d+\\.\\d+)\\b',t,flags=re.MULTILINE);cv=m.group(1) if m else '';print('version.json=',v);print('changelog=',cv);sys.exit(0 if v and m and v==cv else 1)"
# Output:
# version.json= 0.6.0
# changelog= 0.6.0
```

Refs #61
