### PR TITLE
feat(#59): add automated release workflow on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build repository zip artifact
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          artifact_name="${GITHUB_REPOSITORY#*/}-${tag}.zip"
+
+          git archive --format=zip --output "${artifact_name}" "${GITHUB_SHA}"
+
+          echo "artifact_name=${artifact_name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Extract changelog notes for tag version
+        id: notes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          notes_file="release-notes.md"
+
+          if [[ ! -f CHANGELOG.md ]]; then
+            printf 'Release %s\n\nNo CHANGELOG.md found.\n' "${tag}" > "${notes_file}"
+            echo "notes_file=${notes_file}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if awk -v tag="${tag}" -v version="${version}" '
+            function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+            BEGIN { capture = 0; found = 0 }
+            {
+              if ($0 ~ /^##[[:space:]]+/) {
+                heading = $0
+                normalized = heading
+                sub(/^##[[:space:]]+/, "", normalized)
+                gsub(/\[/, "", normalized)
+                gsub(/\]/, "", normalized)
+                split(normalized, parts, " - ")
+                heading_version = trim(parts[1])
+
+                if (capture == 1) {
+                  exit 0
+                }
+
+                if (heading_version == tag || heading_version == version) {
+                  capture = 1
+                  found = 1
+                  print $0
+                  next
+                }
+              }
+
+              if (capture == 1) {
+                print $0
+              }
+            }
+            END { if (found == 0) exit 2 }
+          ' CHANGELOG.md > "${notes_file}"; then
+            :
+          else
+            printf 'Release %s\n\nNo CHANGELOG entry found for `%s` (or `%s`).\n' "${tag}" "${tag}" "${version}" > "${notes_file}"
+          fi
+
+          echo "notes_file=${notes_file}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          artifact="${{ steps.package.outputs.artifact_name }}"
+          notes="${{ steps.notes.outputs.notes_file }}"
+
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${tag}" "${artifact}" --clobber --repo "${GITHUB_REPOSITORY}"
+            gh release edit "${tag}" --notes-file "${notes}" --repo "${GITHUB_REPOSITORY}"
+          else
+            gh release create "${tag}" "${artifact}" \
+              --title "${tag}" \
+              --notes-file "${notes}" \
+              --repo "${GITHUB_REPOSITORY}"
+          fi


### PR DESCRIPTION
## Summary
Implements automated release workflow for version tag pushes.

## Changes
- Adds `.github/workflows/release.yml`
- Triggers on tag pushes matching `v*.*.*`
- Builds zip artifact from tagged commit using `git archive`
- Extracts release notes from `CHANGELOG.md` for matching tag/version (`vX.Y.Z` and `X.Y.Z` supported)
- Creates or updates GitHub Release and attaches zip artifact

Closes #59

## Test Evidence
- `git diff --check main...HEAD` (no whitespace/errors)
- Static workflow checks passed for:
  - tag trigger pattern `v*.*.*`
  - zip creation command `git archive --format=zip`
  - changelog extraction step
  - release create/update commands (`gh release create`, `gh release edit`)
