### PR TITLE
feat(ci): add PR validation workflow (closes #58)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,178 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-lint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run markdown lint on changed markdown files
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          mapfile -t md_files < <(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- '*.md')
+
+          if [[ ${#md_files[@]} -eq 0 ]]; then
+            echo "No markdown files changed in this PR."
+            exit 0
+          fi
+
+          printf '%s\n' "Markdown files to lint:" "${md_files[@]}"
+          npm install --global markdownlint-cli@0.39.0
+          markdownlint "${md_files[@]}"
+
+  gitleaks-scan:
+    name: Gitleaks secret scan (warn only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.18.4"
+        run: |
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Run gitleaks scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          set +e
+          gitleaks detect \
+            --config .gitleaks.toml \
+            --source . \
+            --log-opts "origin/${{ github.base_ref }}..HEAD" \
+            --report-format sarif \
+            --report-path gitleaks-pr-validation.sarif \
+            --no-banner \
+            --redact \
+            --exit-code 1
+          EXIT_CODE=$?
+          set -e
+
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "::warning::Gitleaks detected potential secrets. Review gitleaks-pr-validation.sarif."
+          else
+            echo "No secrets detected by gitleaks."
+          fi
+
+      - name: Upload gitleaks artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-pr-validation-report
+          path: gitleaks-pr-validation.sarif
+          if-no-files-found: warn
+          retention-days: 7
+
+  validate-agent-files:
+    name: Validate agent file structure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate required sections in agents/*.agent.md
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          files=(agents/*.agent.md)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No agent files found under agents/. Nothing to validate."
+            exit 0
+          fi
+
+          for file in "${files[@]}"; do
+            echo "Validating $file"
+
+            if [[ "$(sed -n '1p' "$file")" != "---" ]]; then
+              echo "Missing frontmatter start ('---') in $file" >&2
+              exit 1
+            fi
+
+            if ! sed -n '1,25p' "$file" | grep -qi '^description:'; then
+              echo "Missing description in frontmatter for $file" >&2
+              exit 1
+            fi
+
+            if ! grep -Eq '^## Inputs$' "$file"; then
+              echo "Missing required section '## Inputs' in $file" >&2
+              exit 1
+            fi
+
+            if ! grep -Eq '^## (Process|Workflow)$' "$file"; then
+              echo "Missing required section '## Process' or '## Workflow' in $file" >&2
+              exit 1
+            fi
+
+            if ! grep -Eq '^## .*(Output|Report)\b' "$file"; then
+              echo "Missing required output/report section in $file." >&2
+              exit 1
+            fi
+          done
+
+          echo "Agent file structure validation passed."
+
+  sync-dry-run:
+    name: Sync script dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Execute sync.sh in an isolated temp repo
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tmp_root="$(mktemp -d)"
+          trap 'rm -rf "$tmp_root"' EXIT
+
+          consumer_repo="$tmp_root/consumer"
+          mkdir -p "$consumer_repo"
+          git -C "$consumer_repo" init -q
+          git -C "$consumer_repo" config user.name "pr-validation"
+          git -C "$consumer_repo" config user.email "pr-validation@example.com"
+          touch "$consumer_repo/README.md"
+          git -C "$consumer_repo" add README.md
+          git -C "$consumer_repo" commit -m "init" -q
+
+          (
+            cd "$consumer_repo"
+            BASECOAT_REPO="https://github.com/${{ github.repository }}.git" \
+            BASECOAT_REF="main" \
+            BASECOAT_TARGET_DIR=".github/base-coat" \
+            bash "$GITHUB_WORKSPACE/sync.sh"
+          )
+
+          test -f "$consumer_repo/.github/base-coat/README.md"
+          test -d "$consumer_repo/.github/base-coat/agents"
+          test -d "$consumer_repo/.github/base-coat/instructions"
+          echo "sync.sh dry-run passed."

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -1,0 +1,148 @@
+name: Consumer Sync Validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  sync-consumer-test:
+    name: ${{ matrix.os }} - ${{ matrix.script }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            script: sync.sh
+          - os: windows-latest
+            script: sync.ps1
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare source and consumer repositories (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SOURCE_REPO="$RUNNER_TEMP/basecoat-source"
+          CONSUMER_REPO="$RUNNER_TEMP/basecoat-consumer"
+
+          git clone --no-hardlinks "$GITHUB_WORKSPACE" "$SOURCE_REPO"
+          git -C "$SOURCE_REPO" checkout -B ci-ref "$GITHUB_SHA"
+
+          mkdir -p "$CONSUMER_REPO"
+          git -C "$CONSUMER_REPO" init
+
+          {
+            echo "SOURCE_REPO=$SOURCE_REPO"
+            echo "CONSUMER_REPO=$CONSUMER_REPO"
+            echo "TARGET_DIR=.github/base-coat"
+          } >> "$GITHUB_ENV"
+
+      - name: Prepare source and consumer repositories (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $sourceRepo = Join-Path $env:RUNNER_TEMP 'basecoat-source'
+          $consumerRepo = Join-Path $env:RUNNER_TEMP 'basecoat-consumer'
+
+          git clone --no-hardlinks $env:GITHUB_WORKSPACE $sourceRepo | Out-Null
+          git -C $sourceRepo checkout -B ci-ref $env:GITHUB_SHA | Out-Null
+
+          New-Item -Path $consumerRepo -ItemType Directory -Force | Out-Null
+          git -C $consumerRepo init | Out-Null
+
+          Add-Content -Path $env:GITHUB_ENV -Value "SOURCE_REPO=$sourceRepo"
+          Add-Content -Path $env:GITHUB_ENV -Value "CONSUMER_REPO=$consumerRepo"
+          Add-Content -Path $env:GITHUB_ENV -Value "TARGET_DIR=.github/base-coat"
+
+      - name: Run sync.sh and validate output (Linux)
+        if: matrix.script == 'sync.sh'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$CONSUMER_REPO"
+
+          output="$(BASECOAT_REPO="$SOURCE_REPO" BASECOAT_REF="ci-ref" BASECOAT_TARGET_DIR="$TARGET_DIR" bash "$GITHUB_WORKSPACE/sync.sh" 2>&1)"
+          echo "$output"
+
+          if [[ "$output" != *"Base Coat synced into $TARGET_DIR"* ]]; then
+            echo "Expected success message not found in sync.sh output" >&2
+            exit 1
+          fi
+
+      - name: Run sync.ps1 and validate output (Windows)
+        if: matrix.script == 'sync.ps1'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-Location $env:CONSUMER_REPO
+
+          $env:BASECOAT_REPO = $env:SOURCE_REPO
+          $env:BASECOAT_REF = 'ci-ref'
+          $env:BASECOAT_TARGET_DIR = $env:TARGET_DIR
+
+          $output = & pwsh -NoProfile -File "$env:GITHUB_WORKSPACE/sync.ps1" 2>&1 | Out-String
+          Write-Host $output
+
+          if ($output -notmatch [regex]::Escape("Base Coat synced into $env:TARGET_DIR")) {
+            throw 'Expected success message not found in sync.ps1 output'
+          }
+
+      - name: Validate synced content (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target="$CONSUMER_REPO/$TARGET_DIR"
+          test -d "$target"
+
+          expected=(README.md CHANGELOG.md INVENTORY.md version.json instructions skills prompts agents)
+          for item in "${expected[@]}"; do
+            test -e "$target/$item"
+          done
+
+          unexpected=(.git tests test fixtures sync.sh sync.ps1)
+          for item in "${unexpected[@]}"; do
+            if [[ -e "$target/$item" ]]; then
+              echo "Unexpected item found in target: $item" >&2
+              exit 1
+            fi
+          done
+
+      - name: Validate synced content (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $target = Join-Path $env:CONSUMER_REPO $env:TARGET_DIR
+          if (-not (Test-Path -Path $target -PathType Container)) {
+            throw "Target directory missing: $target"
+          }
+
+          $expected = @('README.md', 'CHANGELOG.md', 'INVENTORY.md', 'version.json', 'instructions', 'skills', 'prompts', 'agents')
+          foreach ($item in $expected) {
+            $full = Join-Path $target $item
+            if (-not (Test-Path -Path $full)) {
+              throw "Expected item missing: $item"
+            }
+          }
+
+          $unexpected = @('.git', 'tests', 'test', 'fixtures', 'sync.sh', 'sync.ps1')
+          foreach ($item in $unexpected) {
+            $full = Join-Path $target $item
+            if (Test-Path -Path $full) {
+              throw "Unexpected item found in target: $item"
+            }
+          }


### PR DESCRIPTION
## Summary\nAdds a reusable pull request validation workflow for Basecoat governance.\n\n## What this workflow does\n- Triggers on pull_request targeting main\n- Lints changed markdown files\n- Runs gitleaks secret scan in warn-only mode (artifact uploaded)\n- Validates gents/*.agent.md structure for required sections\n- Executes sync.sh dry-run in an isolated temp repository\n\n## Test evidence\nLocal validation run before push:\n- Agent structure checks passed locally\n- sync.ps1 dry-run simulation passed locally\n\n`	ext\nAgent structure checks passed locally\nBase Coat synced into .github/base-coat\nsync.ps1 dry-run simulation passed locally\n`\n\ncloses #58