### PR TITLE
feat(#53): add release-manager agent and release process docs

### DIFF
--- a/agents/release-manager.agent.md
+++ b/agents/release-manager.agent.md
@@ -1,0 +1,260 @@
+---
+name: release-manager
+description: "Automated versioned release workflow. Reads merged PRs since the last release, bumps version.json, writes CHANGELOG entry, creates git tag, and publishes GitHub release."
+tools: [run_terminal_command, read_file, write_file, list_dir]
+---
+
+# Release Manager Agent
+
+Purpose: automate the full release lifecycle — determine the next version from merged work, update version metadata, write a changelog entry, tag the commit, and publish a GitHub release — all following semver and Keep a Changelog conventions.
+
+## Inputs
+
+- Repository path or remote URL
+- Release type override (optional): `major`, `minor`, or `patch` — if omitted, the agent infers the type from PR labels and commit prefixes
+- Target branch (optional, default: `main`)
+- Dry run flag (optional, default: `false`) — when `true`, prints what would happen without making changes
+- PR-based review flag (optional, default: `false`) — when `true`, opens a version-bump PR instead of tagging directly
+
+## Workflow
+
+### Step 1 — Determine the Last Release
+
+Read `version.json` to get the current version, then find the corresponding git tag.
+
+```bash
+CURRENT_VERSION=$(jq -r '.version' version.json)
+LAST_TAG="v${CURRENT_VERSION}"
+
+# Verify the tag exists
+if ! git rev-parse "${LAST_TAG}" >/dev/null 2>&1; then
+  echo "WARNING: tag ${LAST_TAG} not found — using first commit as baseline"
+  LAST_TAG=$(git rev-list --max-parents=0 HEAD)
+fi
+```
+
+### Step 2 — Collect Merged PRs Since Last Release
+
+Use `gh` to list merged PRs since the last tag date.
+
+```bash
+TAG_DATE=$(git log -1 --format=%aI "${LAST_TAG}" 2>/dev/null || echo "2000-01-01T00:00:00Z")
+
+gh pr list \
+  --state merged \
+  --base main \
+  --search "merged:>=${TAG_DATE}" \
+  --json number,title,labels,body,mergedAt \
+  --limit 200
+```
+
+### Step 3 — Classify the Version Bump
+
+Scan PR titles, labels, and conventional commit prefixes to determine the bump level.
+
+| Signal | Bump |
+|---|---|
+| Label `breaking-change` or PR title contains `BREAKING CHANGE` | **major** |
+| Label `enhancement` or `feature`, or title starts with `feat` | **minor** |
+| Label `bug` or `fix`, or title starts with `fix`, `docs`, `chore` | **patch** |
+
+Apply the highest applicable bump. If an explicit override was provided in Inputs, use that instead.
+
+```bash
+# Parse CURRENT_VERSION into components
+IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT_VERSION}"
+
+case "${BUMP}" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+esac
+
+NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+```
+
+### Step 4 — Update `version.json`
+
+Write the new version and today's date.
+
+```bash
+RELEASE_DATE=$(date -u +%Y-%m-%d)
+
+jq --arg v "${NEXT_VERSION}" --arg d "${RELEASE_DATE}" \
+  '.version = $v | .releaseDate = $d' \
+  version.json > version.json.tmp && mv version.json.tmp version.json
+```
+
+### Step 5 — Write CHANGELOG Entry
+
+Generate a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) entry grouped by change type. Insert the new section immediately after the `# Changelog` header and preamble.
+
+```markdown
+## <NEXT_VERSION> - <RELEASE_DATE>
+
+### Added
+- <entries from feat PRs>
+
+### Changed
+- <entries from refactor or enhancement PRs>
+
+### Fixed
+- <entries from fix PRs>
+
+### Removed
+- <entries from removal PRs>
+```
+
+**Formatting rules:**
+
+- Each entry is a single bullet: `- <PR title> (#<number>)`
+- Omit empty sections (e.g., do not include `### Removed` if no removals)
+- Preserve all existing content below the new entry unchanged
+- The heading format is `## X.Y.Z - YYYY-MM-DD` (no `v` prefix, matching existing CHANGELOG.md)
+
+### Step 6 — Commit the Version Bump
+
+```bash
+git add version.json CHANGELOG.md
+git commit -m "chore: bump version to v${NEXT_VERSION}
+
+- Updated version.json to ${NEXT_VERSION}
+- Added CHANGELOG entry for ${NEXT_VERSION}
+- Release date: ${RELEASE_DATE}"
+```
+
+### Step 7 — Branch Strategy
+
+**If PR-based review is enabled (`--pr`):**
+
+```bash
+BRANCH="release/v${NEXT_VERSION}"
+git checkout -b "${BRANCH}"
+git push origin "${BRANCH}"
+
+gh pr create \
+  --base main \
+  --head "${BRANCH}" \
+  --title "chore: release v${NEXT_VERSION}" \
+  --body "## Release v${NEXT_VERSION}
+
+This PR bumps the version to **${NEXT_VERSION}** and adds the CHANGELOG entry.
+
+### Merged PRs included in this release
+<list of PRs>
+
+### Checklist
+- [ ] version.json updated
+- [ ] CHANGELOG.md entry added
+- [ ] CI checks pass
+
+Once merged, tag and publish with:
+\`\`\`bash
+git tag v${NEXT_VERSION}
+git push origin v${NEXT_VERSION}
+\`\`\`"
+```
+
+**If direct tagging (default):**
+
+```bash
+git tag "v${NEXT_VERSION}"
+git push origin main
+git push origin "v${NEXT_VERSION}"
+```
+
+### Step 8 — Publish GitHub Release
+
+After the tag is pushed, create the release using the CHANGELOG section as notes. The existing `release.yml` workflow handles artifact packaging automatically, but the agent can also create the release directly.
+
+```bash
+# Extract the changelog section for this version
+NOTES=$(awk -v ver="${NEXT_VERSION}" '
+  /^## / {
+    if (found) exit
+    if (index($0, ver)) { found=1; next }
+  }
+  found { print }
+' CHANGELOG.md)
+
+gh release create "v${NEXT_VERSION}" \
+  --title "v${NEXT_VERSION}" \
+  --notes "${NOTES}" \
+  --repo "${OWNER}/${REPO}"
+```
+
+> **Note:** If the `release.yml` or `package-basecoat.yml` workflow is active, pushing the tag will also trigger automated release packaging. The agent should not duplicate artifact uploads in that case.
+
+## Dry Run Mode
+
+When `--dry-run` is set, the agent performs Steps 1–5 but does **not** commit, tag, push, or create a release. Instead, it prints:
+
+```
+DRY RUN — Release v<NEXT_VERSION>
+  Bump type: <major|minor|patch>
+  Current:   <CURRENT_VERSION>
+  Next:      <NEXT_VERSION>
+  PRs:       <count> merged since <LAST_TAG>
+  CHANGELOG: <preview of new section>
+```
+
+## Output Report
+
+```markdown
+## Release Report
+
+**Version:** v<NEXT_VERSION>
+**Previous:** v<CURRENT_VERSION>
+**Bump type:** <major|minor|patch>
+**Date:** <RELEASE_DATE>
+**Branch:** main
+
+### Merged PRs Included
+
+| PR | Title | Type |
+|----|-------|------|
+| #42 | feat: add new agent | minor |
+| #43 | fix: changelog format | patch |
+
+### Files Modified
+
+- `version.json` — version bumped to <NEXT_VERSION>
+- `CHANGELOG.md` — new section added
+
+### Actions Taken
+
+- [x] version.json updated
+- [x] CHANGELOG.md entry written
+- [x] Commit created: `chore: bump version to v<NEXT_VERSION>`
+- [x] Tag created: `v<NEXT_VERSION>`
+- [x] Tag pushed to origin
+- [x] GitHub release published
+
+### Next Steps
+
+- Verify the release at: https://github.com/<owner>/<repo>/releases/tag/v<NEXT_VERSION>
+- Confirm `package-basecoat.yml` completed successfully (if applicable)
+- Notify consumers of the new version
+```
+
+## Error Handling
+
+| Condition | Action |
+|---|---|
+| `version.json` missing or malformed | Stop with error — do not guess |
+| No merged PRs since last release | Stop — nothing to release |
+| Git tag already exists for computed version | Stop with error — version collision |
+| `gh` CLI not authenticated | Stop with error — cannot query PRs or create release |
+| CHANGELOG.md missing | Create it with the standard header before adding the entry |
+| Dirty working tree | Stop with error — require clean state |
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Do not make code changes without a logged GitHub issue.
+- **PRs only**: Never commit directly to `main`. Open a PR, self-approve if needed.
+- **No secrets**: Never commit credentials, tokens, API keys, or sensitive data.
+- **Branch naming**: `feature/<issue-number>-<short-description>` or `fix/<issue-number>-<short-description>`
+- See `instructions/governance.instructions.md` for the full governance reference.
+- See `docs/RELEASE_PROCESS.md` for the human-readable release process this agent automates.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,236 @@
+# Release Process
+
+This document describes how basecoat releases are created — whether by the `release-manager` agent or by a human following the same steps manually. It is the single source of truth for the release workflow.
+
+---
+
+## Overview
+
+basecoat follows [Semantic Versioning 2.0.0](https://semver.org/) and [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/). Every release produces:
+
+1. An updated `version.json`
+2. A new section in `CHANGELOG.md`
+3. A git tag (`vMAJOR.MINOR.PATCH`)
+4. A GitHub release with notes extracted from the changelog
+
+---
+
+## Version Bump Rules
+
+```
+MAJOR.MINOR.PATCH
+```
+
+| Increment | When | Examples |
+|---|---|---|
+| **MAJOR** | Breaking change to consuming repo contract — file moves, schema changes, removed required files | Renaming `instructions/` to `standards/`, changing `version.json` schema |
+| **MINOR** | New agents, skills, instructions, templates, or non-breaking additions | Adding `agents/release-manager.agent.md`, new skill folder |
+| **PATCH** | Bug fixes, typos, CI tweaks, documentation corrections | Fixing a broken link, correcting a regex in a workflow |
+
+When in doubt, prefer the lower bump. A `feat` that adds content without changing contracts is `minor`, not `major`.
+
+---
+
+## Prerequisites
+
+Before starting a release, verify:
+
+- [ ] All PRs for the release are merged to `main`
+- [ ] CI is green on `main` — no failing checks
+- [ ] No secrets, tokens, or PII in any merged content
+- [ ] `gh` CLI is installed and authenticated (`gh auth status`)
+- [ ] Working tree is clean (`git status` shows no changes)
+
+---
+
+## Release Steps
+
+### 1. Identify What Changed
+
+List merged PRs since the last release tag:
+
+```bash
+CURRENT_VERSION=$(jq -r '.version' version.json)
+LAST_TAG="v${CURRENT_VERSION}"
+
+gh pr list \
+  --state merged \
+  --base main \
+  --search "merged:>=$(git log -1 --format=%aI ${LAST_TAG})" \
+  --json number,title,labels \
+  --limit 200
+```
+
+Review the list. Determine the appropriate bump level using the rules above.
+
+### 2. Bump `version.json`
+
+Update the `version`, `releaseDate`, and optionally the `notes` field:
+
+```json
+{
+    "name": "base-coat",
+    "version": "X.Y.Z",
+    "releaseDate": "YYYY-MM-DD",
+    "notes": "Brief summary of what this release includes."
+}
+```
+
+### 3. Update `CHANGELOG.md`
+
+Add a new section immediately after the preamble, above existing entries. Follow this format:
+
+```markdown
+## X.Y.Z - YYYY-MM-DD
+
+### Added
+- Description of new feature (#PR)
+
+### Changed
+- Description of change (#PR)
+
+### Fixed
+- Description of bug fix (#PR)
+```
+
+**Rules:**
+
+- Use the heading format `## X.Y.Z - YYYY-MM-DD` (no `v` prefix — matches existing convention)
+- Group entries under `Added`, `Changed`, `Fixed`, `Removed` per Keep a Changelog
+- Omit empty groups — do not include `### Removed` if nothing was removed
+- Each entry references its PR number: `(#42)`
+- Preserve all existing content below the new section unchanged
+- If a single-line-per-PR style is already in use (as in prior releases), maintain that style for consistency
+
+### 4. Commit the Version Bump
+
+```bash
+git add version.json CHANGELOG.md
+git commit -m "chore: bump version to vX.Y.Z"
+```
+
+### 5. Choose: Direct Tag or PR Review
+
+#### Option A — Direct Tag (for maintainers)
+
+```bash
+git push origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+#### Option B — Release PR (for team review)
+
+```bash
+git checkout -b release/vX.Y.Z
+git push origin release/vX.Y.Z
+
+gh pr create \
+  --base main \
+  --head release/vX.Y.Z \
+  --title "chore: release vX.Y.Z" \
+  --body "Bumps version to X.Y.Z and adds CHANGELOG entry. Once merged, tag with:
+\`\`\`
+git tag vX.Y.Z && git push origin vX.Y.Z
+\`\`\`"
+```
+
+After the PR is merged, pull `main` and create the tag:
+
+```bash
+git checkout main && git pull origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### 6. Publish GitHub Release
+
+Pushing a `v*.*.*` tag triggers the `release.yml` and `package-basecoat.yml` workflows automatically. These workflows:
+
+1. Build a source archive (`basecoat-vX.Y.Z.zip`)
+2. Extract the changelog section for this version
+3. Create a GitHub release with the archive and notes
+
+If you need to create the release manually (e.g., workflows are disabled):
+
+```bash
+gh release create vX.Y.Z \
+  --title "vX.Y.Z" \
+  --notes-file release-notes.md \
+  --repo ivegamsft/basecoat
+```
+
+### 7. Post-Release Verification
+
+After the release is published:
+
+- [ ] GitHub release page shows correct notes and artifacts
+- [ ] `package-basecoat.yml` workflow completed successfully
+- [ ] `release.yml` workflow completed successfully
+- [ ] Tag `vX.Y.Z` appears in the repository's tag list
+- [ ] `version.json` on `main` reflects the released version
+
+---
+
+## Using the Release Manager Agent
+
+The `release-manager` agent (`agents/release-manager.agent.md`) automates Steps 1–6 above. Invoke it with:
+
+- **Default (direct tag):** The agent identifies merged PRs, bumps the version, writes the changelog, commits, tags, and publishes.
+- **With PR review:** Pass the PR-based review flag to have the agent open a release PR instead of tagging directly.
+- **Dry run:** Preview what the release would contain without making any changes.
+
+The agent follows the same rules documented here. It does not invent its own conventions.
+
+---
+
+## Hotfix Releases
+
+For urgent fixes that cannot wait for a full sprint cycle:
+
+1. Branch from the latest release tag: `git checkout -b fix/<issue>-<desc> vX.Y.Z`
+2. Apply the fix, commit with `fix(<scope>): <description>`
+3. Open a PR to `main`
+4. After merge, follow the normal release steps with a `patch` bump
+
+---
+
+## Rollback
+
+If a release introduces a critical issue:
+
+1. Revert the problematic commit(s) on `main`
+2. Follow the release steps with a new `patch` version
+3. Do **not** delete or move existing tags — they are immutable history
+4. Note the rollback in the CHANGELOG entry for the new version
+
+---
+
+## FAQ
+
+**Q: Can I skip the CHANGELOG?**
+No. Every tagged release must have a corresponding CHANGELOG entry. The `version-check.yml` workflow enforces that `version.json` and CHANGELOG headings stay in sync.
+
+**Q: What if I need to re-release the same version?**
+Don't. Increment the patch version instead. Semver versions are immutable.
+
+**Q: What if the release workflow fails?**
+Check the Actions tab. The `release.yml` workflow uses `gh release create` on first publish and `gh release upload` + `gh release edit` if the release already exists. You can re-run the workflow or create the release manually.
+
+**Q: Who can cut a release?**
+Per `docs/GOVERNANCE.md`, CI/CD changes (including releases) are decided by the repo owner. In practice, anyone with push access to `main` and tag permissions can follow this process.
+
+---
+
+## Related Documents
+
+| Document | Purpose |
+|---|---|
+| `docs/GOVERNANCE.md` | Versioning policy, sprint process, decision-making |
+| `CONTRIBUTING.md` | Branch naming, commit format, PR process |
+| `version.json` | Machine-readable current version |
+| `CHANGELOG.md` | Human-readable release history |
+| `.github/workflows/release.yml` | Tag-triggered release automation |
+| `.github/workflows/package-basecoat.yml` | Tag-triggered packaging and artifact upload |
+| `.github/workflows/version-check.yml` | CI check for version/CHANGELOG consistency |
+| `agents/release-manager.agent.md` | Agent that automates this process |


### PR DESCRIPTION
## Summary

Closes #53

Adds the **release-manager** agent and supporting **RELEASE_PROCESS.md** documentation.

### Files Added

| File | Purpose |
|---|---|
| `agents/release-manager.agent.md` | Agent definition — automated versioned release workflow |
| `docs/RELEASE_PROCESS.md` | Human-readable release process documentation |

### Agent Capabilities

The release-manager agent automates the full release lifecycle:

1. **Reads merged PRs** since the last release tag via `gh pr list`
2. **Classifies version bump** (major/minor/patch) from PR labels and conventional commit prefixes
3. **Bumps `version.json`** with new version and release date
4. **Writes CHANGELOG entry** following Keep a Changelog format, grouped by Added/Changed/Fixed/Removed
5. **Creates git tag** (`vMAJOR.MINOR.PATCH`)
6. **Publishes GitHub release** with changelog notes via `gh release create`
7. **Optionally opens a release PR** for team review before tagging

Supports **dry run** mode to preview releases without making changes.

### Acceptance Criteria Checklist

- [x] `agents/release-manager.agent.md` added with YAML frontmatter (name, description, tools)
- [x] Agent has Inputs, Workflow, and Output Report sections
- [x] Follows semver strictly (major/minor/patch classification table)
- [x] CHANGELOG follows Keep a Changelog format (Added/Changed/Fixed/Removed groups)
- [x] Works with `gh release create` (Step 8)
- [x] Documented in `docs/RELEASE_PROCESS.md`
- [x] Error handling for missing files, dirty state, version collisions
- [x] Governance section references basecoat framework