### PR TITLE
feat(#53): add release-manager agent

### DIFF
--- a/agents/release-manager.agent.md
+++ b/agents/release-manager.agent.md
@@ -1,0 +1,343 @@
+---
+name: release-manager
+description: "Automated versioned release workflow. Reads merged PRs since the last tag, bumps version.json (semver), writes a CHANGELOG entry, creates a git tag, and publishes a GitHub release. Optionally opens a version-bump PR for review before tagging."
+tools: [run_terminal_command, read_file, write_file, create_github_issue]
+---
+
+# Release Manager Agent
+
+Purpose: produce a consistent, repeatable release from a set of merged PRs.
+Every field — version, CHANGELOG entry, tag, and release notes — is derived
+from the same source of truth so version drift is impossible.
+
+## Inputs
+
+- **Bump type** — `major`, `minor`, or `patch` (required)
+- **Repo** — `owner/repo` (defaults to the repo where the agent is invoked)
+- **Dry run** — `true | false` (default: `false`); when `true`, prints every
+  action without executing it — safe for previewing
+- **PR mode** — `pr | direct` (default: `pr`); `pr` opens a version-bump PR
+  for review before tagging; `direct` tags immediately after pushing the bump
+- **Release title override** — optional custom title; defaults to
+  `Release <new-version>`
+- **Since ref** — optional git ref to collect PRs from (defaults to last tag)
+
+## Model
+
+Recommended: claude-sonnet-4.6
+Rationale: Release operations are high-stakes and sequential. The agent must
+reason carefully about semver rules, CHANGELOG format, and git tag order.
+Sonnet provides reliable multi-step reasoning without premium cost.
+Minimum: claude-haiku-4.5 (dry-run previews only — not recommended for
+production releases)
+
+## Workflow
+
+### Step 1 — Determine Current Version
+
+```bash
+# Read version.json from repo root
+CURRENT=$(gh api repos/<owner>/<repo>/contents/version.json \
+  --jq '.content' | base64 -d | python3 -c "import sys,json; print(json.load(sys.stdin)['version'])")
+
+echo "Current version: $CURRENT"
+```
+
+Parse into components:
+```
+MAJOR.MINOR.PATCH  →  e.g. 0.6.0
+```
+
+### Step 2 — Compute New Version (Strict Semver)
+
+Apply bump type:
+
+| Bump | Rule | Example (from 0.6.0) |
+|------|------|----------------------|
+| `patch` | increment PATCH, reset nothing | `0.6.1` |
+| `minor` | increment MINOR, reset PATCH to 0 | `0.7.0` |
+| `major` | increment MAJOR, reset MINOR and PATCH to 0 | `1.0.0` |
+
+```python
+# Python reference implementation
+import re
+parts = [int(x) for x in current.split('.')]
+if bump == 'major':   parts = [parts[0]+1, 0, 0]
+elif bump == 'minor': parts = [parts[0], parts[1]+1, 0]
+elif bump == 'patch': parts = [parts[0], parts[1], parts[2]+1]
+new_version = '.'.join(str(p) for p in parts)
+```
+
+Validate that `new_version > current_version` before proceeding.
+
+### Step 3 — Collect Merged PRs Since Last Tag
+
+```bash
+# Find the commit SHA of the last tag
+LAST_TAG=$(gh api repos/<owner>/<repo>/git/refs/tags \
+  --jq '.[].ref' | grep 'refs/tags/v' | sort -V | tail -1 | sed 's|refs/tags/||')
+
+echo "Last tag: $LAST_TAG"
+
+# List merged PRs since that tag's commit date
+LAST_DATE=$(gh api repos/<owner>/<repo>/git/ref/tags/$LAST_TAG \
+  --jq '.object.sha' | xargs -I{} gh api repos/<owner>/<repo>/commits/{} \
+  --jq '.commit.committer.date')
+
+gh pr list \
+  --repo <owner>/<repo> \
+  --state merged \
+  --json number,title,body,mergedAt,labels \
+  --jq "[.[] | select(.mergedAt > \"$LAST_DATE\")]" \
+  > /tmp/merged-prs.json
+```
+
+Verify at least one PR was collected. If the list is empty, warn and ask
+whether to proceed with an empty CHANGELOG entry.
+
+### Step 4 — Generate CHANGELOG Entry
+
+Format follows [Keep a Changelog](https://keepachangelog.com):
+
+```markdown
+## <new-version> — <YYYY-MM-DD>
+
+<one line per merged PR, formatted as:>
+- <PR title with issue reference if present>
+```
+
+Rules:
+- Date is the UTC date of the release run (`date -u +%Y-%m-%d`)
+- Order PRs by merge date ascending (oldest first)
+- Strip `feat:`, `fix:`, `docs:`, `chore:` prefixes from PR titles for
+  cleaner changelog prose — keep the parenthetical scope if present
+- Skip PRs labeled `skip-changelog` or `internal`
+- Do not include PR numbers in the changelog (they add noise in a public doc)
+
+Example output:
+```markdown
+## 0.7.0 — 2026-04-26
+
+- Added `agents/project-onboarding.agent.md`: single-invocation repo setup with Basecoat integration
+- Added `agents/release-manager.agent.md`: automated versioned release workflow
+- Added `docs/MODEL_OPTIMIZATION.md`: model-per-role recommendations and tier matrix
+- Updated `instructions/governance.instructions.md`: model selection guidance in Section 10
+- Fixed README: sync consumption pattern now leads the document
+```
+
+### Step 5 — Update Files Locally
+
+Clone the repo to a temp directory and create a release branch:
+
+```bash
+git clone https://github.com/<owner>/<repo>.git /tmp/release-<new-version>
+cd /tmp/release-<new-version>
+git config user.email "agent@ci"
+git config user.name "release-manager"
+git checkout -b chore/release-<new-version>
+```
+
+**Update `version.json`:**
+
+```bash
+python3 - << 'EOF'
+import json, datetime
+with open('version.json') as f:
+    v = json.load(f)
+v['version'] = '<new-version>'
+v['releaseDate'] = datetime.date.today().isoformat()
+v['notes'] = '<one-line sprint summary>'
+with open('version.json', 'w') as f:
+    json.dump(v, f, indent=4)
+    f.write('\n')
+EOF
+```
+
+**Prepend CHANGELOG entry:**
+
+```bash
+python3 - << 'EOF'
+with open('CHANGELOG.md') as f:
+    content = f.read()
+# Insert after the first line (the # Changelog heading)
+lines = content.split('\n')
+insert_at = next(i for i, l in enumerate(lines) if l.startswith('## '))
+new_entry = "\n## <new-version> — <date>\n\n<changelog-lines>\n"
+lines.insert(insert_at, new_entry)
+with open('CHANGELOG.md', 'w') as f:
+    f.write('\n'.join(lines))
+EOF
+```
+
+**Stage and commit:**
+
+```bash
+git add version.json CHANGELOG.md
+git commit -m "chore(release): bump to v<new-version>"
+git push origin chore/release-<new-version>
+```
+
+### Step 6 — Open Version-Bump PR (PR mode) or Tag Directly
+
+#### PR mode (default — recommended)
+
+```bash
+gh pr create \
+  --repo <owner>/<repo> \
+  --base main \
+  --head chore/release-<new-version> \
+  --title "chore(release): v<new-version>" \
+  --body "## Release v<new-version>
+
+### CHANGELOG Preview
+<changelog-entry>
+
+### Files Changed
+- \`version.json\`: \`<current>\` → \`<new-version>\`
+- \`CHANGELOG.md\`: new entry prepended
+
+### Checklist
+- [ ] CHANGELOG entry reviewed
+- [ ] Version bump correct (\`<bump-type>\`)
+- [ ] CI passes
+
+After merge, tag and publish: run this agent again with \`PR mode: direct\`
+or create the tag manually:
+\`\`\`bash
+git tag v<new-version> \$(git rev-parse main)
+git push origin v<new-version>
+\`\`\`"
+```
+
+Wait for human approval before tagging. Do not create the tag until the
+version-bump PR is merged to `main`.
+
+#### Direct mode (tag immediately after push)
+
+Only use when the version bump is already on `main` (PR was already merged):
+
+```bash
+# Ensure we are on up-to-date main
+git checkout main && git pull
+
+# Verify version.json matches what we intend to tag
+ACTUAL=$(python3 -c "import json; print(json.load(open('version.json'))['version'])")
+if [ "$ACTUAL" != "<new-version>" ]; then
+  echo "ERROR: version.json is $ACTUAL, expected <new-version>. Aborting."
+  exit 1
+fi
+
+# Create annotated tag
+git tag -a "v<new-version>" -m "Release v<new-version>"
+git push origin "v<new-version>"
+```
+
+### Step 7 — Publish GitHub Release
+
+```bash
+# Extract the CHANGELOG entry for this version as release notes
+python3 - << 'EOF'
+import re
+with open('CHANGELOG.md') as f:
+    content = f.read()
+# Match from this version heading to the next heading
+pattern = r'(## <new-version>.*?)(?=\n## |\Z)'
+match = re.search(pattern, content, re.DOTALL)
+notes = match.group(1).strip() if match else "See CHANGELOG.md"
+with open('/tmp/release-notes.md', 'w') as f:
+    f.write(notes)
+EOF
+
+# Publish the release
+gh release create "v<new-version>" \
+  --repo <owner>/<repo> \
+  --title "<release-title-override or 'Release v<new-version>'>" \
+  --notes-file /tmp/release-notes.md \
+  --verify-tag
+```
+
+If the release already exists (e.g. from a tag-triggered CI workflow),
+upload additional assets and edit the notes:
+
+```bash
+gh release upload "v<new-version>" <asset-files> --clobber
+gh release edit "v<new-version>" --notes-file /tmp/release-notes.md
+```
+
+### Step 8 — Produce Release Report
+
+```markdown
+## Release Manager Report
+**Repo:** <owner>/<repo>
+**Version:** <current> → <new-version>
+**Bump type:** <major|minor|patch>
+**Tag:** v<new-version>
+**Date:** <date>
+
+### PRs Included
+| # | Title | Merged |
+|---|-------|--------|
+| #N | <title> | <date> |
+
+### CHANGELOG Entry
+<changelog-entry>
+
+### Actions Taken
+| Action | Status | Notes |
+|--------|--------|-------|
+| version.json updated | ✅ | |
+| CHANGELOG.md updated | ✅ | |
+| Version-bump PR | ✅ | #<pr-number> |
+| Git tag created | ✅ | v<new-version> |
+| GitHub release published | ✅ | |
+
+### Skipped PRs
+<list of PRs skipped due to skip-changelog label, or "none">
+```
+
+## Dry Run Mode
+
+When `--dry-run` is set, print every action prefixed with `[DRY RUN]` and
+exit without executing. Useful for previewing a release before committing.
+
+```
+[DRY RUN] Would compute: 0.6.0 → 0.7.0 (minor bump)
+[DRY RUN] Would collect 5 PRs merged since tag v0.6.0
+[DRY RUN] Would prepend CHANGELOG entry:
+  ## 0.7.0 — 2026-04-26
+  - Added agents/project-onboarding.agent.md ...
+[DRY RUN] Would update version.json → 0.7.0
+[DRY RUN] Would open PR chore/release-0.7.0
+[DRY RUN] Would create tag v0.7.0 (after PR merge)
+[DRY RUN] Would publish GitHub release v0.7.0
+```
+
+## Error Handling
+
+| Condition | Action |
+|-----------|--------|
+| No PRs collected since last tag | Warn, ask before continuing with empty changelog |
+| `new-version <= current-version` | Abort with error |
+| Tag already exists | Abort with error — never force-push tags |
+| CHANGELOG heading not found | Create heading format and file an issue for manual review |
+| `gh release create` fails | Retry once; on second failure, stop and log issue |
+| version.json JSON invalid | Stop, report parse error, do not write corrupted file |
+
+## Non-Goals
+
+- Does not run tests or CI — release only proceeds on a already-green `main`
+- Does not deploy artifacts to package registries or cloud environments
+- Does not send notifications (Slack, Teams, email) — integrate separately
+- Does not rotate secrets or rotate API keys post-release
+
+## Governance
+
+This agent operates under the basecoat governance framework.
+
+- **Issue-first**: Every release is traceable to merged issues.
+- **PRs only**: Version bump always goes through a PR — no direct `main` commits.
+- **No secrets**: Never commit tokens, keys, or connection strings.
+- **Semver strict**: `new-version > current-version` is a hard precondition.
+- **Tag immutability**: Never force-push or delete existing tags.
+- See `instructions/governance.instructions.md` and `docs/RELEASE_PROCESS.md`
+  for the full reference.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,224 @@
+# Release Process
+
+This document describes how versioned releases of Basecoat are cut,
+tagged, and published. Follow this process for every release regardless
+of size.
+
+---
+
+## Overview
+
+Basecoat uses **semantic versioning** (`MAJOR.MINOR.PATCH`). The source
+of truth for the current version is `version.json` at the repo root.
+The authoritative human-readable history is `CHANGELOG.md`.
+
+---
+
+## Version Artifacts
+
+| Artifact | Location | Update Trigger |
+|----------|----------|---------------|
+| Current version | `version.json` | Every release |
+| Human-readable history | `CHANGELOG.md` | Every release |
+| Git tag | `v<version>` on `main` | After version-bump PR merges |
+| GitHub Release | GitHub Releases page | After git tag is pushed |
+
+These four artifacts must always be in sync. The `version-check.yml`
+CI workflow enforces consistency between `version.json` and `CHANGELOG.md`
+on every PR.
+
+---
+
+## Release Cadence
+
+- **Sprint releases** (minor bumps): cut at the end of each sprint
+- **Hotfixes** (patch bumps): cut ad-hoc when a defect is found in the
+  current release
+- **Breaking changes** (major bumps): planned, announced in an issue first,
+  require explicit human approval before tagging
+
+---
+
+## Step-by-Step Process
+
+### 1. Confirm `main` is Green
+
+All CI checks on `main` must pass before starting a release:
+
+```bash
+gh run list --repo ivegamsft/basecoat --branch main --limit 5
+```
+
+If any workflow is failing, fix it before proceeding.
+
+### 2. Use the Release Manager Agent (Recommended)
+
+The `release-manager` agent automates Steps 3–7. Invoke it with:
+
+```
+Bump type: minor          # or major / patch
+PR mode: pr               # opens a version-bump PR for review
+Dry run: true             # preview first — recommended
+```
+
+Preview the release:
+
+```
+Bump type: minor
+Dry run: true
+```
+
+Execute:
+
+```
+Bump type: minor
+Dry run: false
+PR mode: pr
+```
+
+### 3. Manual Process (if not using the agent)
+
+#### 3a. Collect Merged PRs Since Last Tag
+
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0)
+echo "Last tag: $LAST_TAG"
+
+gh pr list \
+  --repo ivegamsft/basecoat \
+  --state merged \
+  --json number,title,mergedAt \
+  --jq "[.[] | select(.mergedAt > \"$(git log $LAST_TAG -1 --format=%cI)\")]"
+```
+
+#### 3b. Update `version.json`
+
+Edit `version.json`:
+
+```json
+{
+    "name": "base-coat",
+    "version": "<new-version>",
+    "releaseDate": "<YYYY-MM-DD>",
+    "notes": "<one-line sprint summary>"
+}
+```
+
+#### 3c. Update `CHANGELOG.md`
+
+Prepend a new entry before the previous most-recent entry:
+
+```markdown
+## <new-version> — <YYYY-MM-DD>
+
+- <change description>
+- <change description>
+```
+
+Follow [Keep a Changelog](https://keepachangelog.com) conventions:
+- **Added** for new features
+- **Changed** for changes to existing functionality
+- **Fixed** for bug fixes
+- **Removed** for removed features
+
+#### 3d. Open Version-Bump PR
+
+```bash
+git checkout -b chore/release-<new-version>
+git add version.json CHANGELOG.md
+git commit -m "chore(release): bump to v<new-version>"
+git push origin chore/release-<new-version>
+gh pr create --title "chore(release): v<new-version>" --base main
+```
+
+#### 3e. Merge and Tag
+
+After the PR merges to `main`:
+
+```bash
+git checkout main && git pull
+git tag -a "v<new-version>" -m "Release v<new-version>"
+git push origin "v<new-version>"
+```
+
+#### 3f. Publish GitHub Release
+
+The `release.yml` workflow fires automatically on `v*.*.*` tag push and
+publishes the GitHub Release. To publish manually:
+
+```bash
+gh release create "v<new-version>" \
+  --repo ivegamsft/basecoat \
+  --title "Release v<new-version>" \
+  --generate-notes \
+  --verify-tag
+```
+
+---
+
+## Semver Rules
+
+| Bump | When to use |
+|------|-------------|
+| `patch` | Bug fixes, documentation corrections, no new features |
+| `minor` | New agents, skills, instructions — backward-compatible additions |
+| `major` | Breaking changes to the sync contract, file layout, or agent interfaces |
+
+**When in doubt, use `minor`.** Consumers pin to a release tag; a minor bump
+never breaks them.
+
+---
+
+## Tag Immutability
+
+> **Never force-push or delete a tag once it is pushed.**
+
+Tags are permanent. If a mistake is made after tagging:
+
+1. Do NOT delete or move the tag
+2. Fix the mistake on `main`
+3. Cut a new patch release with the fix
+
+---
+
+## Rollback
+
+If a release is discovered to be broken after publishing:
+
+1. Open a GitHub issue describing the defect
+2. Fix on a `fix/<issue>-<slug>` branch
+3. Merge via PR to `main`
+4. Cut a patch release
+
+Do not retract releases or delete tags. Consumers may already be pinned to
+the broken version; deleting it breaks their sync.
+
+---
+
+## CI Integration
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `version-check.yml` | PR to `main`, push to `main` | Validates `version.json` ↔ `CHANGELOG.md` consistency |
+| `release.yml` | Push `v*.*.*` tag | Builds source archive, publishes GitHub Release |
+| `pr-validation.yml` | PR to `main` | Markdownlint, secret scan, agent structure checks |
+
+---
+
+## Checklist
+
+Use this checklist for every release:
+
+```markdown
+## Release Checklist — v<version>
+
+- [ ] main is green (all CI workflows passing)
+- [ ] All sprint PRs merged
+- [ ] version.json bumped to <version>
+- [ ] CHANGELOG.md entry added for <version>
+- [ ] Version-bump PR opened, reviewed, and merged
+- [ ] Git tag v<version> created and pushed
+- [ ] GitHub Release published with release notes
+- [ ] release.yml CI completed successfully
+- [ ] version-check.yml passes on main post-merge
+```


### PR DESCRIPTION
Closes #53

## Summary
Adds \gents/release-manager.agent.md\ and \docs/RELEASE_PROCESS.md\.

## What the agent does
1. Reads current version from \ersion.json\ and computes new semver from bump type (major/minor/patch)
2. Collects all merged PRs since the last git tag via \gh pr list\
3. Generates a CHANGELOG entry from PR titles (Keep a Changelog format)
4. Updates \ersion.json\ and prepends CHANGELOG entry
5. Opens a version-bump PR for review (default) or tags directly (configurable)
6. Creates annotated git tag after merge
7. Publishes GitHub Release using CHANGELOG entry as release notes
8. Produces a structured release report

## Key design decisions
- **PR mode by default**: version bump always goes through a PR — no direct \main\ commits
- **Dry run support**: preview every action without executing (\dry-run: true\)
- **Tag immutability enforced**: errors on existing tags, never force-pushes
- **Integrates with \elease.yml\**: tag push triggers the CI workflow automatically

## docs/RELEASE_PROCESS.md
Human-readable step-by-step release guide covering:
- Version artifact sync (version.json, CHANGELOG, tag, GitHub Release)
- Semver rules table
- Manual fallback process (if not using the agent)
- Tag immutability policy
- Rollback procedure
- CI integration table
- Release checklist

## Validation
- [x] YAML frontmatter (line 1 is \---\)
- [x] \description:\ in first 25 lines
- [x] \## Inputs\ section present
- [x] \## Workflow\ section present
- [x] \## Model\ section present
- [x] \## Governance\ section present
- [x] All \gh\ commands use \--repo\ flag (no hardcoded values)

## Risk
- Risk level: low (additive — two new files)
- Rollback: revert commit or delete files