### PR TITLE
feat(#50): add agent model optimization guide

### DIFF
--- a/agents/backend-dev.agent.md
+++ b/agents/backend-dev.agent.md
@@ -124,6 +124,11 @@ Trigger conditions:
 | Hardcoded value that should be config | `tech-debt,backend` |
 | Endpoint missing authentication or authorization check | `tech-debt,backend,security` |
 
+## Model
+**Recommended:** gpt-5.3-codex
+**Rationale:** Code-optimized model tuned for API implementation, service layers, and data access patterns
+**Minimum:** gpt-5.4-mini
+
 ## Output Format
 
 - Deliver code with inline comments explaining non-obvious decisions.

--- a/agents/code-review.agent.md
+++ b/agents/code-review.agent.md
@@ -26,6 +26,11 @@ Purpose: perform a structured repository or pull request review with emphasis on
 - Open questions
 - Short summary
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Nuanced code analysis requires good reasoning but not premium-tier complexity
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/config-auditor.agent.md
+++ b/agents/config-auditor.agent.md
@@ -161,6 +161,11 @@ config/settings.local.json
 EOF
 ```
 
+## Model
+**Recommended:** claude-haiku-4.5
+**Rationale:** Routine scanning with well-defined patterns — speed and cost matter most
+**Minimum:** gpt-5.4-mini
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/data-tier.agent.md
+++ b/agents/data-tier.agent.md
@@ -135,6 +135,11 @@ Trigger conditions:
 | Migration with no `down` / rollback block | `tech-debt,data,reliability` |
 | Hardcoded ID or environment-specific value in a query or migration | `tech-debt,data` |
 
+## Model
+**Recommended:** gpt-5.3-codex
+**Rationale:** Code-optimized model tuned for schema design, migrations, and query optimization
+**Minimum:** gpt-5.4-mini
+
 ## Output Format
 
 - Deliver schema DDL and migration files with inline comments explaining design decisions.

--- a/agents/exploratory-charter.agent.md
+++ b/agents/exploratory-charter.agent.md
@@ -69,6 +69,11 @@ For each session, produce a charter following `skills/manual-test-strategy/chart
 
 After the session, produce a brief findings summary with filed GitHub Issues for automation candidates.
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Structured thinking and edge case identification for exploratory testing sessions
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/frontend-dev.agent.md
+++ b/agents/frontend-dev.agent.md
@@ -120,6 +120,11 @@ Trigger conditions:
 | Component has no loading state for async data | `tech-debt,frontend` |
 | Inline style object defined inside render function | `tech-debt,frontend,performance` |
 
+## Model
+**Recommended:** gpt-5.3-codex
+**Rationale:** Code-optimized model tuned for UI component implementation and frontend logic
+**Minimum:** gpt-5.4-mini
+
 ## Output Format
 
 - Deliver components with inline comments explaining accessibility decisions and non-obvious state logic.

--- a/agents/manual-test-strategy.agent.md
+++ b/agents/manual-test-strategy.agent.md
@@ -60,6 +60,11 @@ If a sprint label is applicable, append `--label "<sprint-label>"`.
 - Automation backlog list with priorities and filed GitHub Issues
 - PR summary including assumptions, coverage boundaries, and next actions
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Structured thinking for test strategy design, risk classification, and edge case identification
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/merge-coordinator.agent.md
+++ b/agents/merge-coordinator.agent.md
@@ -345,6 +345,11 @@ Produce a structured merge report at completion:
 Target branch <target-branch> updated with N of M branches merged.
 ```
 
+## Model
+**Recommended:** claude-haiku-4.5
+**Rationale:** Routine branch operations with well-defined steps — speed and cost matter most
+**Minimum:** gpt-5.4-mini
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/middleware-dev.agent.md
+++ b/agents/middleware-dev.agent.md
@@ -121,6 +121,11 @@ Trigger conditions:
 | Message handler with no idempotency check | `tech-debt,middleware,reliability` |
 | Missing distributed trace propagation across a service boundary | `tech-debt,middleware,observability` |
 
+## Model
+**Recommended:** gpt-5.3-codex
+**Rationale:** Code-optimized model tuned for integration layer implementation and adapter patterns
+**Minimum:** gpt-5.4-mini
+
 ## Output Format
 
 - Deliver adapters and message handlers with inline comments explaining resilience decisions.

--- a/agents/new-customization.agent.md
+++ b/agents/new-customization.agent.md
@@ -27,6 +27,11 @@ Purpose: turn a broad customization request into the right asset with the right 
 - Validation notes
 - Suggested follow-up assets
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Choosing the right customization primitive requires structured reasoning about scope and reuse
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/project-onboarding.agent.md
+++ b/agents/project-onboarding.agent.md
@@ -378,6 +378,11 @@ This agent is safe to re-run on an existing repository:
 - **Issue templates** — only created if the `.github/ISSUE_TEMPLATE/` directory is missing.
 - **Sprint-1 issue** — a new issue is created each run. Check for duplicates before re-running if this is undesirable.
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Repo scaffolding decisions and sprint goal decomposition need good reasoning depth
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/release-manager.agent.md
+++ b/agents/release-manager.agent.md
@@ -248,6 +248,11 @@ DRY RUN — Release v<NEXT_VERSION>
 | CHANGELOG.md missing | Create it with the standard header before adding the entry |
 | Dirty working tree | Stop with error — require clean state |
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Version classification, changelog generation, and release decisions need good reasoning
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/rollout-basecoat.agent.md
+++ b/agents/rollout-basecoat.agent.md
@@ -28,6 +28,11 @@ Purpose: onboard a repository or portfolio to Base Coat using safe, repeatable r
 - Validation steps
 - Upgrade guidance
 
+## Model
+**Recommended:** claude-haiku-4.5
+**Rationale:** Repeatable rollout steps with well-defined validation — speed and cost matter most
+**Minimum:** gpt-5.4-mini
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/sprint-planner.agent.md
+++ b/agents/sprint-planner.agent.md
@@ -176,6 +176,11 @@ List any of the following detected during planning:
   of the assigned agent.
 - Do not estimate hours or story points unless the user explicitly requests it.
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Goal decomposition, dependency mapping, and wave planning require good reasoning depth
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/agents/strategy-to-automation.agent.md
+++ b/agents/strategy-to-automation.agent.md
@@ -89,6 +89,11 @@ Produce a summary table at the end:
 - Do not assume a particular runner, language, or CI toolchain.
 - Do not defer issue filing — every candidate gets an issue before the session ends.
 
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Converting manual paths to automation specs requires structured thinking and edge case analysis
+**Minimum:** claude-haiku-4.5
+
 ## Governance
 
 This agent operates under the basecoat governance framework.

--- a/docs/MODEL_OPTIMIZATION.md
+++ b/docs/MODEL_OPTIMIZATION.md
@@ -1,0 +1,155 @@
+# Agent Model Optimization Guide
+
+Choosing the right LLM for each agent role is a cost-performance tradeoff. Default-to-cheapest wastes time on retries and low-quality output; default-to-premium wastes money on tasks that don't need it. This guide provides a principled tier matrix so every agent runs on the model that matches its cognitive demand.
+
+> **Discovery context:** During the app-migration-with-ai Sprint 2, all agents defaulted to Haiku. Architect and security tasks underperformed significantly, requiring manual rework. This guide codifies the lessons learned.
+
+---
+
+## Tier Matrix
+
+| Role | Recommended Model | Tier | Rationale |
+|------|------------------|------|-----------|
+| architect | claude-opus-4.6 | Premium | High-stakes design decisions requiring deep, multi-step reasoning |
+| security_analyst | claude-opus-4.6 | Premium | Security analysis requires thorough reasoning and cannot afford shortcuts |
+| reviewer / code-review | claude-sonnet-4.6 | Reasoning | Nuanced code analysis but not premium-tier complexity |
+| researcher | claude-sonnet-4.6 | Reasoning | Analysis and synthesis require good reasoning depth |
+| qa / manual-test-strategy / exploratory-charter / strategy-to-automation | claude-sonnet-4.6 | Reasoning | Structured thinking, edge case identification, test design |
+| backend-dev / frontend-dev / middleware-dev / data-tier / code | gpt-5.3-codex | Code | Code-optimized model tuned for generation, refactoring, and debugging |
+| sprint-planner / release-manager / project-onboarding | claude-sonnet-4.6 | Reasoning | Planning and decomposition need good reasoning, not raw code output |
+| new-customization | claude-sonnet-4.6 | Reasoning | Deciding between customization types requires structured reasoning |
+| merge-coordinator / rollout-basecoat / config-auditor | claude-haiku-4.5 | Fast | Routine automation with well-defined steps — speed and cost matter most |
+| agent-watchdog / sprint-demo | gpt-5.4-mini | Fast | Simple automation tasks with minimal reasoning requirements |
+
+---
+
+## Tier Definitions
+
+### Premium — `claude-opus-4.6`
+
+Use for tasks where a mistake is expensive or irreversible: architecture decisions, security reviews, threat modeling, compliance analysis. These tasks require deep multi-step reasoning, weighing tradeoffs, and producing output that will be trusted without a second opinion.
+
+**Cost:** ~5× Sonnet. Use deliberately.
+
+### Reasoning — `claude-sonnet-4.6`
+
+The workhorse tier. Use for tasks that require genuine analysis — code review, test strategy, planning, research — but where the output will be reviewed by a human or validated by CI before it matters. Good balance of quality and cost.
+
+**Cost:** Baseline reference tier.
+
+### Code — `gpt-5.3-codex`
+
+Use for code generation, refactoring, migration, and debugging. This model is specifically optimized for code tasks and outperforms general-purpose models on implementation work. Not ideal for prose-heavy analysis or strategic reasoning.
+
+**Cost:** Comparable to Sonnet. Value comes from code-specific optimization.
+
+### Fast — `claude-haiku-4.5` / `gpt-5.4-mini`
+
+Use for well-defined, repetitive tasks: file scanning, config auditing, branch operations, rollout scripts, simple automation. The task should have clear inputs, deterministic steps, and easily validated output. If the agent needs to "think," it probably needs a higher tier.
+
+**Cost:** ~10× cheaper than Sonnet. Use aggressively for routine work.
+
+---
+
+## When to Override the Default
+
+Override the recommended model when:
+
+| Situation | Override Direction | Example |
+|-----------|-------------------|---------|
+| Task is unusually complex for the role | ↑ Upgrade one tier | A backend-dev task involving a complex distributed transaction → claude-sonnet-4.6 |
+| Task is unusually simple for the role | ↓ Downgrade one tier | A code-review of a single-line typo fix → claude-haiku-4.5 |
+| Output will not be human-reviewed | ↑ Upgrade one tier | Automated security scan running unattended → claude-opus-4.6 |
+| Output will be heavily reviewed | ↓ Downgrade one tier | Draft PR description that a human will rewrite anyway → claude-haiku-4.5 |
+| Budget is constrained | ↓ Use minimum viable tier | See the Minimum column in each agent's `## Model` section |
+| Task requires cross-domain reasoning | ↑ Upgrade one tier | A backend-dev task that also requires security analysis → claude-sonnet-4.6 |
+
+---
+
+## Cost Considerations
+
+Rough relative cost per million tokens (input + output blended):
+
+| Model | Relative Cost | Best For |
+|-------|--------------|----------|
+| claude-opus-4.6 | 5.0× | Architecture, security, high-stakes reasoning |
+| claude-sonnet-4.6 | 1.0× (baseline) | Analysis, review, planning, test strategy |
+| gpt-5.3-codex | ~1.0× | Code generation, refactoring, debugging |
+| claude-haiku-4.5 | 0.1× | Routine automation, scanning, simple tasks |
+| gpt-5.4-mini | 0.08× | Simple automation, monitoring, formatting |
+
+**Rule of thumb:** If 10 Haiku runs cost less than 1 Sonnet run _and_ the Haiku output is good enough, use Haiku. If a single Opus run saves you from a production incident, use Opus.
+
+---
+
+## Consumer Configuration
+
+### In agent `.md` files
+
+Each agent file includes a `## Model` section:
+
+```markdown
+## Model
+**Recommended:** claude-sonnet-4.6
+**Rationale:** Analysis tasks need good reasoning depth
+**Minimum:** claude-haiku-4.5
+```
+
+- **Recommended** — use this model by default
+- **Rationale** — why this tier was chosen (helps future reviewers)
+- **Minimum** — the cheapest model that can still complete the task acceptably; use when budget is constrained or the specific invocation is simple
+
+### In orchestration code
+
+When spawning agents programmatically, pass the model as a parameter:
+
+```javascript
+// Use the recommended model from the agent's ## Model section
+const result = await spawnAgent({
+  role: 'backend-dev',
+  model: 'gpt-5.3-codex',   // from agents/backend-dev.agent.md
+  prompt: taskDescription
+});
+```
+
+### In CI/CD pipelines
+
+Set model selection via environment variables:
+
+```yaml
+env:
+  AGENT_MODEL_BACKEND: gpt-5.3-codex
+  AGENT_MODEL_REVIEW: claude-sonnet-4.6
+  AGENT_MODEL_SECURITY: claude-opus-4.6
+  AGENT_MODEL_DEFAULT: claude-haiku-4.5
+```
+
+---
+
+## Agent Template Pattern
+
+When creating a new agent, include the `## Model` section in the `.agent.md` file. Place it immediately before the `## Governance` section:
+
+```markdown
+## Model
+**Recommended:** <model-name>
+**Rationale:** <one line explaining why this tier>
+**Minimum:** <cheapest acceptable model>
+```
+
+Choose the tier based on the cognitive demand of the agent's primary task:
+
+| Cognitive Demand | Tier | Model |
+|-----------------|------|-------|
+| Deep multi-step reasoning, high-stakes decisions | Premium | claude-opus-4.6 |
+| Analysis, structured thinking, planning | Reasoning | claude-sonnet-4.6 |
+| Code generation, refactoring, implementation | Code | gpt-5.3-codex |
+| Routine steps, scanning, simple automation | Fast | claude-haiku-4.5 or gpt-5.4-mini |
+
+---
+
+## Related References
+
+- `instructions/governance.instructions.md` — Section 10 covers model awareness policy
+- Individual agent files in `agents/` — each contains a `## Model` section
+- Issue [#50](https://github.com/ivegamsft/basecoat/issues/50) — tracking issue for this guide

--- a/instructions/governance.instructions.md
+++ b/instructions/governance.instructions.md
@@ -172,17 +172,24 @@ Specifically:
 
 ---
 
-## 10. Token and Model Awareness (Stub — Sprint 6)
+## 10. Token and Model Awareness
 
-> **This section is a placeholder. Full implementation is tracked in Issue #44.**
+> **Token budget and cost attribution are tracked in Issue #44. Model selection guidance is now available.**
 
-Planned for Sprint 6:
-- Token budget awareness: agents should track approximate context usage and warn when approaching limits
-- Model selection guidance: which tasks warrant which model tier (fast/cheap vs. standard vs. premium)
-- Context window management: how to chunk large tasks to avoid truncation
-- Cost attribution: tagging agent-driven API calls for cost tracking
+### Model Selection — Match Model to Task Complexity
 
-Until Issue #44 is implemented, agents should:
+Every agent should run on the model tier that matches its cognitive demand:
+
+- **Premium** (`claude-opus-4.6`) — for security analysis and architecture decisions where mistakes are costly
+- **Reasoning** (`claude-sonnet-4.6`) — for code review, test strategy, planning, and research
+- **Code** (`gpt-5.3-codex`) — for code generation, refactoring, and implementation tasks
+- **Fast** (`claude-haiku-4.5` / `gpt-5.4-mini`) — for routine automation, scanning, and simple operations
+
+Each agent's `.agent.md` file includes a `## Model` section with the recommended model, rationale, and minimum viable model. See `docs/MODEL_OPTIMIZATION.md` for the full tier matrix, override guidance, and cost considerations.
+
+### General Token Guidance
+
+Until Issue #44 is fully implemented, agents should:
 - Prefer concise, targeted prompts over large context dumps
 - Break large tasks into discrete issues and PRs rather than one massive context
 - Flag when a task feels too large for a single context window


### PR DESCRIPTION
## Summary

Add a comprehensive model optimization guide and update all agent files with per-role model recommendations. Discovered during app-migration-with-ai S2 sprint when all agents defaulted to Haiku, underperforming for complex tasks.

### Changes

1. **\docs/MODEL_OPTIMIZATION.md\** — Full tier matrix with 4 tiers (Premium, Reasoning, Code, Fast), override guidance, cost considerations, consumer configuration patterns, and agent template pattern documentation.

2. **All 15 agent \.md\ files updated** — Each now includes a \## Model\ section with:
   - Recommended model and rationale
   - Minimum viable model for budget-constrained usage
   - Placed before \## Governance\ (or at end for agents without Governance)

3. **\instructions/governance.instructions.md\** — Section 10 updated from stub placeholder to actionable model selection guidance referencing the full guide.

### Tier Assignments

| Tier | Model | Agents |
|------|-------|--------|
| Premium | claude-opus-4.6 | architect, security_analyst |
| Reasoning | claude-sonnet-4.6 | code-review, manual-test-strategy, exploratory-charter, strategy-to-automation, sprint-planner, release-manager, project-onboarding, new-customization |
| Code | gpt-5.3-codex | backend-dev, frontend-dev, middleware-dev, data-tier |
| Fast | claude-haiku-4.5 | merge-coordinator, rollout-basecoat, config-auditor |

### Validation

- All 15 agent files contain exactly one \## Model\ section (verified via grep)
- \## Model\ is placed before \## Governance\ in all agents that have a Governance section
- Governance Section 10 updated with actionable guidance (no longer a stub)
- No secrets, credentials, or sensitive data committed

## Issue Reference

Closes #50

## Risk

- Risk level: low
- Rollback: revert this single commit