### PR TITLE
feat: merge policy, required status checks, and agent PR verification guardrail (closes #76)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you are an AI agent: **do not begin implementation without an issue number**.
 
 ## Branch Naming
 
-```
+```text
 <type>/<issue-number>-<short-description>
 ```
 
@@ -36,7 +36,8 @@ If you are an AI agent: **do not begin implementation without an issue number**.
 | `security` | Security-related changes |
 
 **Examples:**
-```
+
+```text
 feat/43-governance-docs
 fix/17-hook-glob-pattern
 docs/39-readme-overhaul
@@ -57,12 +58,14 @@ No direct commits to `main`. Ever.
 7. **Squash-merge** preferred to keep `main` history clean.
 
 **PR Title Format:**
-```
+
+```text
 <type>: <short description> (closes #<issue-number>)
 ```
 
 **Examples:**
-```
+
+```text
 feat: governance framework documentation (closes #43)
 fix: commit-msg hook glob pattern (closes #17)
 ```
@@ -71,7 +74,7 @@ fix: commit-msg hook glob pattern (closes #17)
 
 ## Commit Message Format
 
-```
+```text
 <type>(<scope>): <short summary>
 
 - Optional bullet points for detail
@@ -83,6 +86,7 @@ Co-authored-by: <name> <email>  # if applicable
 **Types:** `feat`, `fix`, `docs`, `chore`, `security`, `test`, `refactor`
 
 **Rules:**
+
 - First line ≤ 72 characters
 - Reference the issue number
 - No secrets, tokens, keys, passwords, or PII — ever
@@ -96,6 +100,7 @@ Co-authored-by: <name> <email>  # if applicable
 **Never commit secrets.** This is non-negotiable.
 
 What counts as a secret:
+
 - API keys, tokens, client secrets
 - Passwords, passphrases, PINs
 - Connection strings with credentials embedded
@@ -103,11 +108,13 @@ What counts as a secret:
 - PII (names, emails, IDs) not required for the change
 
 **If you accidentally commit a secret:**
+
 1. Rewrite history immediately (`git rebase`, `git filter-branch`, or BFG)
 2. Rotate the affected credential immediately
 3. Notify the repo owner
 
 The `.githooks/commit-msg` hook scans commit messages for secret patterns. Install it:
+
 ```bash
 bash scripts/install-git-hooks.sh
 # or on Windows:
@@ -119,11 +126,13 @@ pwsh scripts/install-git-hooks.ps1
 ## Review Expectations
 
 **For authors:**
+
 - Keep PRs focused — one issue per PR
 - Write a clear summary and validation steps in the PR description
 - Call out any deviations from standards and why
 
 **For reviewers:**
+
 - Check that the change matches the linked issue
 - Verify no secrets or PII are present
 - Confirm tests or validation steps are included where applicable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,71 @@ All new agents, skills, and instructions require an issue before implementation.
 
 ---
 
+## Merge Policy & Build Verification
+
+**This section is mandatory for all contributors — human and AI alike.**
+
+### Branch Protection Rules
+
+The `main` branch enforces the following protections:
+
+- **No direct commits** — all changes must arrive via a pull request
+- **Required status checks must pass** before any merge is allowed
+- **Stale review dismissal** — approvals are invalidated if new commits are pushed after approval
+- **At least one approval** required before merge
+
+### Required Status Checks
+
+Every PR targeting `main` must pass **all** of the following checks before it can be merged:
+
+| Check Name | Workflow | Purpose |
+|---|---|---|
+| `Markdown lint` | `pr-validation.yml` | Lints changed `.md` files against markdownlint rules |
+| `Validate agent file structure` | `pr-validation.yml` | Verifies agents have required frontmatter and sections |
+| `Sync script dry-run` | `pr-validation.yml` | Validates sync.sh runs cleanly against a temp consumer repo |
+| `version-consistency` | `version-check.yml` | Ensures version.json and latest CHANGELOG.md entry match |
+| `prd-spec-gate` | `prd-spec-gate.yml` | Requires PRD/spec links for high-change or risky PRs |
+| `validate-commit-messages` | `validate-basecoat.yml` | Scans commit messages for secrets and PII patterns |
+| `validate-unix` | `validate-basecoat.yml` | Runs full validation suite on Ubuntu |
+| `validate-windows` | `validate-basecoat.yml` | Runs full validation suite on Windows |
+
+> **Note:** `Gitleaks` scans run as warn-only and do **not** block merge by design.
+> Findings must be reviewed and remediated, but they will not prevent a passing build
+> from being merged.
+
+### Agent Guardrail — Mandatory Build Verification Step
+
+**Any AI agent that opens or works a PR must perform this verification before declaring the work done:**
+
+```bash
+# Verify all required checks are green before closing a PR
+gh pr checks <PR-NUMBER> --repo <owner>/<repo>
+
+# Expected: every listed check shows a ✓ pass status.
+# Do NOT merge or mark work complete if any check is pending or failing.
+```
+
+Agents must:
+
+1. Open the PR
+2. Wait for the check suite to run (poll with `gh pr checks` until all are complete)
+3. Confirm every required check shows **pass** status
+4. Only then mark the PR as ready to merge / work as done
+
+**Do not declare a PR "done" because it was opened. The PR is done when checks pass and it is merged.**
+
+### No Auto-Merge
+
+Auto-merge is not enabled. Merges require:
+
+1. All required status checks green
+2. At least one approval
+3. No unresolved conversations
+
+This is intentional — catching a broken build post-merge is significantly more expensive than the few minutes it takes to confirm checks passed first.
+
+---
+
 ## Questions
 
 Open an issue with the `question` label. Do not DM maintainers for things that belong in the open.


### PR DESCRIPTION
## Summary

Closes #76

Adds a **Merge Policy & Build Verification** section to \CONTRIBUTING.md\ that codifies exactly how PRs may be merged — for humans and AI agents alike.

## Changes

- **CONTRIBUTING.md** — new section documenting:
  - Branch protection rules in effect on \main\
  - Table of all 8 required CI status checks with workflow source and purpose
  - Agent guardrail: mandatory \gh pr checks\ verification before declaring work done
  - No-auto-merge policy and approval requirements

## Required Status Checks Registered

The following checks are configured as required on \main\ branch protection:

| Check | Workflow |
|---|---|
| \Markdown lint\ | pr-validation.yml |
| \Validate agent file structure\ | pr-validation.yml |
| \Sync script dry-run\ | pr-validation.yml |
| \ersion-consistency\ | version-check.yml |
| \prd-spec-gate\ | prd-spec-gate.yml |
| \alidate-commit-messages\ | validate-basecoat.yml |
| \alidate-unix\ | validate-basecoat.yml |
| \alidate-windows\ | validate-basecoat.yml |

## Validation

- \CONTRIBUTING.md\ is the only changed file — markdownlint will run on it
- No agent files, scripts, or workflow files touched — prd-spec-gate will not require a spec link
- version.json and CHANGELOG.md are unchanged — version-consistency will pass