### PR TITLE
fix: remove staging dir after packaging to fix release upload

### DIFF
--- a/scripts/package-basecoat.sh
+++ b/scripts/package-basecoat.sh
@@ -29,4 +29,9 @@ tar -C "$DIST_DIR/stage" -czf "$DIST_DIR/$ARCHIVE_BASE.tar.gz" base-coat
 
 (cd "$DIST_DIR" && sha256sum "$ARCHIVE_BASE.zip" "$ARCHIVE_BASE.tar.gz" > SHA256SUMS.txt)
 
+# Clean up staging directory so dist/ only contains release-ready files.
+# Without this, `dist/*` globs (used by upload-artifact and gh release upload)
+# include the stage directory, which causes upload failures. Fixes #86.
+rm -rf "$DIST_DIR/stage"
+
 echo "Packaged artifacts into $DIST_DIR"


### PR DESCRIPTION
## Summary
Fixes #86 — the **Package Base Coat** workflow has been failing on tagged releases (v0.6.0, v0.7.0) because `dist/stage/` (a temporary staging directory) was included in the `dist/*` glob.

## Root Cause
`scripts/package-basecoat.sh` creates `dist/stage/base-coat/` to assemble archive contents, then builds `.zip` and `.tar.gz` from it — but never removes the staging directory. When the workflow runs `gh release upload dist/*`, it tries to upload the directory as an asset and fails:

\\\
read dist/stage: is a directory
\\\

## Fix
Add `rm -rf "$DIST_DIR/stage"` after archive creation (line 33) so `dist/` only contains:
- `base-coat-X.Y.Z.zip`
- `base-coat-X.Y.Z.tar.gz`
- `SHA256SUMS.txt`

## Testing
- One-line change, low risk
- Can verify by re-running the Package Base Coat workflow on the v0.7.0 tag after merge